### PR TITLE
Enforce strict schema-1 mapping contracts

### DIFF
--- a/.github/workflows/application-verification.yml
+++ b/.github/workflows/application-verification.yml
@@ -111,6 +111,96 @@ jobs:
           --logger "trx;LogFileName=Promptly.Application.UnitTests.trx"
           --results-directory artifacts/test-results/csharp
 
+      - name: Require complete measured C# cohort
+        shell: pwsh
+        run: |
+          [xml]$coverage = Get-Content artifacts/test-results/csharp/coverage/coverage.cobertura.xml -Raw
+          $packages = @($coverage.coverage.packages.package)
+          $actualAssemblies = @(
+            $packages |
+              Where-Object { @($_.classes.class).Count -gt 0 } |
+              ForEach-Object { [string]$_.name }
+          ) | Sort-Object
+          $expectedAssemblies = @("Promptly.Application")
+          $assemblyDifference = Compare-Object $expectedAssemblies $actualAssemblies
+          if ($assemblyDifference) {
+            throw "Unexpected measured C# assembly cohort: $($assemblyDifference | Out-String)"
+          }
+
+          function Get-RepositoryRelativePath([string]$path) {
+            $fullPath = if ([IO.Path]::IsPathRooted($path)) {
+              [IO.Path]::GetFullPath($path)
+            }
+            else {
+              [IO.Path]::GetFullPath((Join-Path (Get-Location).Path $path))
+            }
+            return [IO.Path]::GetRelativePath((Get-Location).Path, $fullPath).Replace('\', '/')
+          }
+
+          $applicationPackage = $packages |
+            Where-Object { $_.name -eq "Promptly.Application" } |
+            Select-Object -First 1
+          $actualApplicationSources = @(
+            $applicationPackage.classes.class |
+              ForEach-Object { Get-RepositoryRelativePath ([string]$_.filename) }
+          ) | Sort-Object -Unique
+          $expectedApplicationSources = @(
+            "Promptly.Application/Services/BoundedRegexMatcher.cs"
+            "Promptly.Application/Services/ExpectationEvaluator.cs"
+            "Promptly.Application/Services/MappingService.cs"
+          ) | Sort-Object
+          $applicationDifference = Compare-Object `
+            $expectedApplicationSources `
+            $actualApplicationSources
+          if ($applicationDifference) {
+            throw "Unexpected scoped Application coverage cohort: $($applicationDifference | Out-String)"
+          }
+
+          $lineRate = [double]::Parse(
+            [string]$applicationPackage.'line-rate',
+            [Globalization.CultureInfo]::InvariantCulture)
+          $branchRate = [double]::Parse(
+            [string]$applicationPackage.'branch-rate',
+            [Globalization.CultureInfo]::InvariantCulture)
+          if ($lineRate -lt 0.90 -or $branchRate -lt 0.90) {
+            throw "Application cohort coverage is below 90%: line=$lineRate branch=$branchRate"
+          }
+          Write-Host "Promptly.Application: line=$('{0:P2}' -f $lineRate) branch=$('{0:P2}' -f $branchRate)"
+
+          $requiredClasses = @(
+            "Promptly.Application.Services.BoundedRegexMatcher"
+            "Promptly.Application.Services.ExpectationEvaluator"
+            "Promptly.Application.Services.MappingService"
+            "Promptly.Application.Services.MappingSpecValidationException"
+          ) | Sort-Object
+          $actualTopLevelClasses = @(
+            $applicationPackage.classes.class |
+              Where-Object { ([string]$_.name) -notmatch '/' } |
+              ForEach-Object { [string]$_.name }
+          ) | Sort-Object -Unique
+          $classDifference = Compare-Object $requiredClasses $actualTopLevelClasses
+          if ($classDifference) {
+            throw "Unexpected top-level Application coverage class cohort: $($classDifference | Out-String)"
+          }
+          foreach ($className in $requiredClasses) {
+            $class = @($applicationPackage.classes.class) |
+              Where-Object { $_.name -eq $className } |
+              Select-Object -First 1
+            if (-not $class) {
+              throw "Required covered class is missing: $className"
+            }
+            $classLineRate = [double]::Parse(
+              [string]$class.'line-rate',
+              [Globalization.CultureInfo]::InvariantCulture)
+            $classBranchRate = [double]::Parse(
+              [string]$class.'branch-rate',
+              [Globalization.CultureInfo]::InvariantCulture)
+            if ($classLineRate -lt 0.90 -or $classBranchRate -lt 0.90) {
+              throw "Coverage for $className is below 90%: line=$classLineRate branch=$classBranchRate"
+            }
+            Write-Host "${className}: line=$('{0:P2}' -f $classLineRate) branch=$('{0:P2}' -f $classBranchRate)"
+          }
+
       - name: Require test and coverage artifacts
         shell: pwsh
         run: |

--- a/Promptly.Application/Interfaces/IMappingService.cs
+++ b/Promptly.Application/Interfaces/IMappingService.cs
@@ -23,4 +23,5 @@ public record MappingResult
     public bool Success { get; init; }
     public CanonicalTrace? Trace { get; init; }
     public string? ErrorMessage { get; init; }
+    public string? ErrorPath { get; init; }
 }

--- a/Promptly.Application/Models/MappingModels.cs
+++ b/Promptly.Application/Models/MappingModels.cs
@@ -28,6 +28,7 @@ public record ValidateMappingResponse
     public bool Success { get; init; }
     public CanonicalTrace? PreviewTrace { get; init; }
     public string? ErrorMessage { get; init; }
+    public string? ErrorPath { get; init; }
 }
 
 public record CreateMappingSpecRequest

--- a/Promptly.Application/Services/MappingService.cs
+++ b/Promptly.Application/Services/MappingService.cs
@@ -1,10 +1,13 @@
+using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Promptly.Application.Data;
 using Promptly.Application.Interfaces;
 using Promptly.Domain.Entities;
 using Promptly.Domain.ValueObjects;
-using Promptly.Application.Data;
 
 namespace Promptly.Application.Services;
 
@@ -14,6 +17,18 @@ public class MappingService : IMappingService
     private readonly ILogger<MappingService> _logger;
     private readonly PromptlyDbContext _dbContext;
     private const int MaxRawResponseSize = 200 * 1024; // 200KB
+    private const long MaxCompatibleJsonPathIndex = 9_007_199_254_740_991;
+    private static readonly JsonSerializerOptions MappingSpecJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = false,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow
+    };
+    private const string CompatibleJsonPathPattern =
+        """^\$(?:\.[A-Za-z_][A-Za-z0-9_]*|\[(?:0|[1-9][0-9]*|\*)\]|\["[^"\\\u0000-\u001F]*"\]|\['[^'\\\u0000-\u001F]*'\])*$""";
+    private static readonly Regex CompatibleJsonPathRegex = new(
+        CompatibleJsonPathPattern,
+        RegexOptions.CultureInvariant | RegexOptions.NonBacktracking,
+        TimeSpan.FromMilliseconds(100));
 
     public MappingService(IJsonPathService jsonPathService, ILogger<MappingService> logger, PromptlyDbContext dbContext)
     {
@@ -36,15 +51,8 @@ public class MappingService : IMappingService
     {
         try
         {
-            var mappingSpec = JsonSerializer.Deserialize<MappingSpecDefinition>(mappingSpecJson);
-            if (mappingSpec == null)
-            {
-                return new MappingResult
-                {
-                    Success = false,
-                    ErrorMessage = "Invalid mapping spec JSON"
-                };
-            }
+            var mappingSpec = DeserializeAndValidateMappingSpec(mappingSpecJson);
+            ValidateResponseJson(responseJson);
 
             var trace = new CanonicalTrace
             {
@@ -61,14 +69,363 @@ public class MappingService : IMappingService
                 Trace = trace
             };
         }
+        catch (MappingSpecValidationException ex)
+        {
+            _logger.LogWarning(ex, "Invalid mapping specification at {MappingPath}", ex.Path);
+            return new MappingResult
+            {
+                Success = false,
+                ErrorMessage = ex.Message,
+                ErrorPath = ex.Path
+            };
+        }
+        catch (MappingException ex)
+        {
+            _logger.LogWarning(ex, "Mapping validation failed at {MappingPath}", ex.Path);
+            return new MappingResult
+            {
+                Success = false,
+                ErrorMessage = ex.Message,
+                ErrorPath = ex.Path
+            };
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to apply mapping spec");
             return new MappingResult
             {
                 Success = false,
-                ErrorMessage = $"Mapping failed: {ex.Message}"
+                ErrorMessage = "Mapping failed due to an unexpected error"
             };
+        }
+    }
+
+    private MappingSpecDefinition DeserializeAndValidateMappingSpec(string mappingSpecJson)
+    {
+        if (string.IsNullOrWhiteSpace(mappingSpecJson))
+        {
+            throw new MappingSpecValidationException(
+                "mappingSpec",
+                "a schema-1 JSON object is required");
+        }
+
+        MappingSpecDefinition? spec;
+        try
+        {
+            using var document = JsonDocument.Parse(mappingSpecJson);
+            if (ContainsDuplicateObjectProperty(document.RootElement))
+            {
+                throw new MappingSpecValidationException(
+                    "mappingSpec",
+                    "the JSON contains duplicate property names");
+            }
+
+            spec = document.RootElement.Deserialize<MappingSpecDefinition>(MappingSpecJsonOptions);
+        }
+        catch (MappingSpecValidationException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException)
+        {
+            throw new MappingSpecValidationException(
+                ex is JsonException jsonException
+                    ? NormalizeJsonExceptionPath(jsonException.Path)
+                    : "mappingSpec",
+                "the JSON does not match schema 1",
+                ex);
+        }
+
+        if (spec == null)
+        {
+            throw new MappingSpecValidationException(
+                "mappingSpec",
+                "a schema-1 JSON object is required");
+        }
+
+        ValidateMappingSpec(spec);
+        return spec;
+    }
+
+    private static void ValidateResponseJson(string responseJson)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(responseJson);
+            if (ContainsDuplicateObjectProperty(document.RootElement))
+            {
+                throw new MappingException(
+                    "responseJson",
+                    "response JSON contains duplicate property names");
+            }
+        }
+        catch (MappingException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException)
+        {
+            throw new MappingException("responseJson", "response is not valid JSON", ex);
+        }
+    }
+
+    private static bool ContainsDuplicateObjectProperty(JsonElement element)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            var names = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var property in element.EnumerateObject())
+            {
+                if (!names.Add(property.Name)
+                    || ContainsDuplicateObjectProperty(property.Value))
+                {
+                    return true;
+                }
+            }
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in element.EnumerateArray())
+            {
+                if (ContainsDuplicateObjectProperty(item))
+                {
+                    return true;
+                }
+            }
+        }
+        else if (element.ValueKind == JsonValueKind.String)
+        {
+            _ = element.GetString();
+        }
+
+        return false;
+    }
+
+    private static string NormalizeJsonExceptionPath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || path == "$")
+        {
+            return "mappingSpec";
+        }
+
+        return path.StartsWith("$.", StringComparison.Ordinal)
+            ? path[2..]
+            : path.TrimStart('$');
+    }
+
+    private void ValidateMappingSpec(MappingSpecDefinition spec)
+    {
+        if (spec.Messages == null
+            && spec.ToolCalls == null
+            && spec.Usage == null
+            && spec.RetrievedDocs == null
+            && spec.Fallback == null)
+        {
+            throw new MappingSpecValidationException(
+                "mappingSpec",
+                "at least one extraction section is required");
+        }
+
+        if (spec.Version != 1)
+        {
+            var versionDetail = spec.Version == null
+                ? "the required schema version is missing"
+                : $"unsupported mapping version {spec.Version}; only schema 1 is supported";
+            throw new MappingSpecValidationException(
+                "version",
+                versionDetail);
+        }
+
+        if (spec.Messages != null)
+        {
+            RequirePaths(
+                (spec.Messages.ItemsPath, "messages.itemsPath"),
+                (spec.Messages.RolePath, "messages.rolePath"),
+                (spec.Messages.ContentPath, "messages.contentPath"));
+        }
+
+        if (spec.ToolCalls != null)
+        {
+            RequirePaths(
+                (spec.ToolCalls.ItemsPath, "toolCalls.itemsPath"),
+                (spec.ToolCalls.NamePath, "toolCalls.namePath"),
+                (spec.ToolCalls.ArgumentsPath, "toolCalls.argumentsPath"));
+        }
+
+        if (spec.Usage != null)
+        {
+            RequirePaths((spec.Usage.ObjectPath, "usage.objectPath"));
+            (string? Path, string Label)[] metricPaths =
+            [
+                (spec.Usage.PromptTokensPath, "usage.promptTokensPath"),
+                (spec.Usage.CompletionTokensPath, "usage.completionTokensPath"),
+                (spec.Usage.TotalTokensPath, "usage.totalTokensPath"),
+                (spec.Usage.CostPath, "usage.costPath"),
+                (spec.Usage.LatencyMsPath, "usage.latencyMsPath")
+            ];
+            if (metricPaths.All(metric => metric.Path == null))
+            {
+                throw new MappingSpecValidationException(
+                    "usage",
+                    "at least one metric path is required");
+            }
+
+            ValidateOptionalPaths(metricPaths);
+        }
+
+        if (spec.RetrievedDocs != null)
+        {
+            RequirePaths(
+                (spec.RetrievedDocs.ItemsPath, "retrievedDocs.itemsPath"),
+                (spec.RetrievedDocs.ContentPath, "retrievedDocs.contentPath"));
+            ValidateOptionalPaths(
+                (spec.RetrievedDocs.IdPath, "retrievedDocs.idPath"),
+                (spec.RetrievedDocs.TitlePath, "retrievedDocs.titlePath"),
+                (spec.RetrievedDocs.MetadataPath, "retrievedDocs.metadataPath"));
+        }
+
+        if (spec.Fallback != null)
+        {
+            RequirePaths((
+                spec.Fallback.SingleAssistantContentPath,
+                "fallback.singleAssistantContentPath"));
+        }
+
+        ValidateJsonPathSyntax(GetConfiguredPaths(spec));
+    }
+
+    private static void RequirePaths(params (string? Path, string Label)[] paths)
+    {
+        foreach (var (path, label) in paths)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new MappingSpecValidationException(
+                    label,
+                    "a non-empty JSONPath is required");
+            }
+        }
+    }
+
+    private static void ValidateOptionalPaths(params (string? Path, string Label)[] paths)
+    {
+        foreach (var (path, label) in paths)
+        {
+            if (path != null && string.IsNullOrWhiteSpace(path))
+            {
+                throw new MappingSpecValidationException(
+                    label,
+                    "the JSONPath cannot be empty");
+            }
+        }
+    }
+
+    private void ValidateJsonPathSyntax(
+        IEnumerable<(string? Path, string Label)> configuredPaths)
+    {
+        foreach (var (path, label) in configuredPaths.Where(item => item.Path != null))
+        {
+            if (!CompatibleJsonPathRegex.IsMatch(path!) || UsesUnsupportedArrayIndex(path!))
+            {
+                throw new MappingSpecValidationException(
+                    label,
+                    $"'{path}' uses unsupported JSONPath syntax");
+            }
+
+            try
+            {
+                _jsonPathService.SelectToken("{}", path!);
+            }
+            catch (Exception ex)
+            {
+                throw new MappingSpecValidationException(
+                    label,
+                    $"'{path}' is not a valid JSONPath",
+                    ex);
+            }
+        }
+    }
+
+    private static bool UsesUnsupportedArrayIndex(string path)
+    {
+        var position = 1;
+        while (position < path.Length)
+        {
+            if (path[position] == '.')
+            {
+                position++;
+                while (position < path.Length && path[position] != '.' && path[position] != '[')
+                {
+                    position++;
+                }
+
+                continue;
+            }
+
+            var selectorStart = position + 1;
+            if (path[selectorStart] is '"' or '\'')
+            {
+                var quote = path[selectorStart];
+                position = path.IndexOf(quote, selectorStart + 1) + 2;
+                continue;
+            }
+
+            var selectorEnd = path.IndexOf(']', selectorStart);
+            var selector = path.AsSpan(selectorStart, selectorEnd - selectorStart);
+            if (selector[0] != '*'
+                && (!long.TryParse(selector, out var index)
+                    || index > MaxCompatibleJsonPathIndex))
+            {
+                return true;
+            }
+
+            position = selectorEnd + 1;
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<(string? Path, string Label)> GetConfiguredPaths(
+        MappingSpecDefinition spec)
+    {
+        if (spec.Messages != null)
+        {
+            yield return (spec.Messages.ItemsPath, "messages.itemsPath");
+            yield return (spec.Messages.RolePath, "messages.rolePath");
+            yield return (spec.Messages.ContentPath, "messages.contentPath");
+        }
+
+        if (spec.ToolCalls != null)
+        {
+            yield return (spec.ToolCalls.ItemsPath, "toolCalls.itemsPath");
+            yield return (spec.ToolCalls.NamePath, "toolCalls.namePath");
+            yield return (spec.ToolCalls.ArgumentsPath, "toolCalls.argumentsPath");
+        }
+
+        if (spec.Usage != null)
+        {
+            yield return (spec.Usage.ObjectPath, "usage.objectPath");
+            yield return (spec.Usage.PromptTokensPath, "usage.promptTokensPath");
+            yield return (spec.Usage.CompletionTokensPath, "usage.completionTokensPath");
+            yield return (spec.Usage.TotalTokensPath, "usage.totalTokensPath");
+            yield return (spec.Usage.CostPath, "usage.costPath");
+            yield return (spec.Usage.LatencyMsPath, "usage.latencyMsPath");
+        }
+
+        if (spec.RetrievedDocs != null)
+        {
+            yield return (spec.RetrievedDocs.ItemsPath, "retrievedDocs.itemsPath");
+            yield return (spec.RetrievedDocs.IdPath, "retrievedDocs.idPath");
+            yield return (spec.RetrievedDocs.TitlePath, "retrievedDocs.titlePath");
+            yield return (spec.RetrievedDocs.ContentPath, "retrievedDocs.contentPath");
+            yield return (spec.RetrievedDocs.MetadataPath, "retrievedDocs.metadataPath");
+        }
+
+        if (spec.Fallback != null)
+        {
+            yield return (
+                spec.Fallback.SingleAssistantContentPath,
+                "fallback.singleAssistantContentPath");
         }
     }
 
@@ -76,37 +433,47 @@ public class MappingService : IMappingService
     {
         var messages = new List<Message>();
 
-        try
+        if (spec.Messages != null)
         {
-            if (spec.Messages != null && !string.IsNullOrWhiteSpace(spec.Messages.ItemsPath))
+            try
             {
-                var messageItems = _jsonPathService.SelectTokens(responseJson, spec.Messages.ItemsPath);
+                var messageItems = SelectRequiredTokens(
+                    responseJson,
+                    spec.Messages.ItemsPath!,
+                    "messages.itemsPath");
+                RequireObjectItems(messageItems, spec.Messages.ItemsPath!, "messages.itemsPath");
 
                 foreach (var item in messageItems)
                 {
                     var itemJson = item.GetRawText();
-                    var role = ExtractStringValue(itemJson, spec.Messages.RolePath) ?? "assistant";
-                    var content = ExtractContentValue(itemJson, spec.Messages.ContentPath) ?? "";
+                    var role = ExtractRequiredStringValue(
+                        itemJson,
+                        spec.Messages.RolePath,
+                        "messages.rolePath");
+                    var content = ExtractRequiredContentValue(
+                        itemJson,
+                        spec.Messages.ContentPath,
+                        "messages.contentPath");
 
                     messages.Add(new Message { Role = role, Content = content });
                 }
 
                 return messages;
             }
-
-            // Fallback: try to get single assistant content
-            if (spec.Fallback != null && !string.IsNullOrWhiteSpace(spec.Fallback.SingleAssistantContentPath))
+            catch (MappingException ex) when (spec.Fallback != null)
             {
-                var content = ExtractStringValue(responseJson, spec.Fallback.SingleAssistantContentPath);
-                if (!string.IsNullOrWhiteSpace(content))
-                {
-                    messages.Add(new Message { Role = "assistant", Content = content });
-                }
+                _logger.LogWarning(ex, "Messages mapping failed; applying configured fallback");
+                messages.Clear();
             }
         }
-        catch (Exception ex)
+
+        if (spec.Fallback != null)
         {
-            _logger.LogWarning(ex, "Failed to extract messages, using empty list");
+            var content = ExtractRequiredStringValue(
+                responseJson,
+                spec.Fallback.SingleAssistantContentPath!,
+                "fallback.singleAssistantContentPath");
+            messages.Add(new Message { Role = "assistant", Content = content });
         }
 
         return messages;
@@ -114,27 +481,29 @@ public class MappingService : IMappingService
 
     private List<ToolCall> ExtractToolCalls(MappingSpecDefinition spec, string responseJson)
     {
-        var toolCalls = new List<ToolCall>();
-
-        try
+        if (spec.ToolCalls == null)
         {
-            if (spec.ToolCalls != null && !string.IsNullOrWhiteSpace(spec.ToolCalls.ItemsPath))
-            {
-                var toolCallItems = _jsonPathService.SelectTokens(responseJson, spec.ToolCalls.ItemsPath);
-
-                foreach (var item in toolCallItems)
-                {
-                    var itemJson = item.GetRawText();
-                    var name = ExtractStringValue(itemJson, spec.ToolCalls.NamePath) ?? "";
-                    var arguments = ExtractArgumentsValue(itemJson, spec.ToolCalls.ArgumentsPath) ?? "{}";
-
-                    toolCalls.Add(new ToolCall { Name = name, ArgumentsJson = arguments });
-                }
-            }
+            return [];
         }
-        catch (Exception ex)
+
+        var toolCallItems = SelectRequiredTokens(
+            responseJson,
+            spec.ToolCalls.ItemsPath!,
+            "toolCalls.itemsPath");
+        RequireObjectItems(toolCallItems, spec.ToolCalls.ItemsPath!, "toolCalls.itemsPath");
+        var toolCalls = new List<ToolCall>(toolCallItems.Count);
+        foreach (var item in toolCallItems)
         {
-            _logger.LogWarning(ex, "Failed to extract tool calls, using empty list");
+            var itemJson = item.GetRawText();
+            var name = ExtractRequiredStringValue(
+                itemJson,
+                spec.ToolCalls.NamePath,
+                "toolCalls.namePath");
+            var arguments = ExtractRequiredArgumentsValue(
+                itemJson,
+                spec.ToolCalls.ArgumentsPath,
+                "toolCalls.argumentsPath");
+            toolCalls.Add(new ToolCall { Name = name, ArgumentsJson = arguments });
         }
 
         return toolCalls;
@@ -142,265 +511,360 @@ public class MappingService : IMappingService
 
     private Usage? ExtractUsage(MappingSpecDefinition spec, string responseJson)
     {
-        try
+        if (spec.Usage == null)
         {
-            if (spec.Usage != null && !string.IsNullOrWhiteSpace(spec.Usage.ObjectPath))
-            {
-                var usageToken = _jsonPathService.SelectToken(responseJson, spec.Usage.ObjectPath);
-                if (usageToken == null)
-                {
-                    return null;
-                }
-
-                var usageJson = usageToken.Value.GetRawText();
-
-                return new Usage
-                {
-                    PromptTokens = ExtractIntValue(usageJson, spec.Usage.PromptTokensPath),
-                    CompletionTokens = ExtractIntValue(usageJson, spec.Usage.CompletionTokensPath),
-                    TotalTokens = ExtractIntValue(usageJson, spec.Usage.TotalTokensPath),
-                    Cost = ExtractDecimalValue(usageJson, spec.Usage.CostPath),
-                    LatencyMs = ExtractLongValue(usageJson, spec.Usage.LatencyMsPath)
-                };
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to extract usage, returning null");
+            return null;
         }
 
-        return null;
+        var usageObject = SelectRequiredToken(
+            responseJson,
+            spec.Usage.ObjectPath!,
+            "usage.objectPath");
+        if (usageObject.ValueKind != JsonValueKind.Object)
+        {
+            throw new MappingException(
+                "usage.objectPath",
+                $"JSONPath '{spec.Usage.ObjectPath}' did not match an object");
+        }
+
+        var usageJson = usageObject.GetRawText();
+        return new Usage
+        {
+            PromptTokens = ExtractConfiguredIntValue(
+                usageJson,
+                spec.Usage.PromptTokensPath,
+                "usage.promptTokensPath"),
+            CompletionTokens = ExtractConfiguredIntValue(
+                usageJson,
+                spec.Usage.CompletionTokensPath,
+                "usage.completionTokensPath"),
+            TotalTokens = ExtractConfiguredIntValue(
+                usageJson,
+                spec.Usage.TotalTokensPath,
+                "usage.totalTokensPath"),
+            Cost = ExtractConfiguredDecimalValue(
+                usageJson,
+                spec.Usage.CostPath,
+                "usage.costPath"),
+            LatencyMs = ExtractConfiguredLongValue(
+                usageJson,
+                spec.Usage.LatencyMsPath,
+                "usage.latencyMsPath")
+        };
     }
 
     private List<RetrievedDoc> ExtractRetrievedDocs(MappingSpecDefinition spec, string responseJson)
     {
-        var docs = new List<RetrievedDoc>();
-
-        try
+        if (spec.RetrievedDocs == null)
         {
-            if (spec.RetrievedDocs != null && !string.IsNullOrWhiteSpace(spec.RetrievedDocs.ItemsPath))
-            {
-                var docItems = _jsonPathService.SelectTokens(responseJson, spec.RetrievedDocs.ItemsPath);
-
-                foreach (var item in docItems)
-                {
-                    var itemJson = item.GetRawText();
-                    var id = ExtractStringValue(itemJson, spec.RetrievedDocs.IdPath);
-                    var title = ExtractStringValue(itemJson, spec.RetrievedDocs.TitlePath);
-                    var content = ExtractStringValue(itemJson, spec.RetrievedDocs.ContentPath) ?? "";
-
-                    Dictionary<string, object>? metadata = null;
-                    if (!string.IsNullOrWhiteSpace(spec.RetrievedDocs.MetadataPath))
-                    {
-                        var metadataToken = _jsonPathService.SelectToken(itemJson, spec.RetrievedDocs.MetadataPath);
-                        if (metadataToken != null)
-                        {
-                            metadata = JsonSerializer.Deserialize<Dictionary<string, object>>(metadataToken.Value.GetRawText());
-                        }
-                    }
-
-                    docs.Add(new RetrievedDoc
-                    {
-                        Id = id,
-                        Title = title,
-                        Content = content,
-                        Metadata = metadata
-                    });
-                }
-            }
+            return [];
         }
-        catch (Exception ex)
+
+        var docItems = SelectRequiredTokens(
+            responseJson,
+            spec.RetrievedDocs.ItemsPath!,
+            "retrievedDocs.itemsPath");
+        RequireObjectItems(docItems, spec.RetrievedDocs.ItemsPath!, "retrievedDocs.itemsPath");
+        RequireOptionalPathMatch(
+            docItems,
+            spec.RetrievedDocs.IdPath,
+            "retrievedDocs.idPath");
+        RequireOptionalPathMatch(
+            docItems,
+            spec.RetrievedDocs.TitlePath,
+            "retrievedDocs.titlePath");
+        RequireOptionalPathMatch(
+            docItems,
+            spec.RetrievedDocs.MetadataPath,
+            "retrievedDocs.metadataPath");
+        var docs = new List<RetrievedDoc>(docItems.Count);
+        foreach (var item in docItems)
         {
-            _logger.LogWarning(ex, "Failed to extract retrieved docs, using empty list");
+            var itemJson = item.GetRawText();
+            docs.Add(new RetrievedDoc
+            {
+                Id = ExtractOptionalIdValue(
+                    itemJson,
+                    spec.RetrievedDocs.IdPath,
+                    "retrievedDocs.idPath"),
+                Title = ExtractOptionalStringValue(
+                    itemJson,
+                    spec.RetrievedDocs.TitlePath,
+                    "retrievedDocs.titlePath"),
+                Content = ExtractRequiredStringValue(
+                    itemJson,
+                    spec.RetrievedDocs.ContentPath!,
+                    "retrievedDocs.contentPath"),
+                Metadata = ExtractOptionalMetadataValue(
+                    itemJson,
+                    spec.RetrievedDocs.MetadataPath,
+                    "retrievedDocs.metadataPath")
+            });
         }
 
         return docs;
     }
 
-    private string? ExtractStringValue(string json, string? path)
+    private void RequireOptionalPathMatch(
+        IReadOnlyList<JsonElement> items,
+        string? path,
+        string label)
     {
-        if (string.IsNullOrWhiteSpace(path))
+        if (path == null)
         {
-            return null;
+            return;
         }
 
-        try
+        if (!items.Any(item => SelectOptionalToken(item.GetRawText(), path, label) != null))
         {
-            var token = _jsonPathService.SelectToken(json, path);
-            if (token == null)
-            {
-                return null;
-            }
-
-            return token.Value.ValueKind == JsonValueKind.String
-                ? token.Value.GetString()
-                : token.Value.GetRawText();
-        }
-        catch
-        {
-            return null;
+            throw new MappingException(label, $"JSONPath '{path}' did not match a value");
         }
     }
 
-    private string? ExtractContentValue(string json, string? path)
+    private static void RequireObjectItems(
+        IReadOnlyList<JsonElement> items,
+        string path,
+        string label)
     {
-        if (string.IsNullOrWhiteSpace(path))
+        if (items.Any(item => item.ValueKind != JsonValueKind.Object))
         {
-            return null;
-        }
-
-        try
-        {
-            var token = _jsonPathService.SelectToken(json, path);
-            if (token == null)
-            {
-                return null;
-            }
-
-            // If content is a string, return it
-            if (token.Value.ValueKind == JsonValueKind.String)
-            {
-                return token.Value.GetString();
-            }
-
-            // If content is an array or object, stringify it
-            if (token.Value.ValueKind == JsonValueKind.Array)
-            {
-                var parts = new List<string>();
-                foreach (var item in token.Value.EnumerateArray())
-                {
-                    if (item.ValueKind == JsonValueKind.String)
-                    {
-                        parts.Add(item.GetString() ?? "");
-                    }
-                    else
-                    {
-                        parts.Add(item.GetRawText());
-                    }
-                }
-                return string.Join("\n", parts);
-            }
-
-            return token.Value.GetRawText();
-        }
-        catch
-        {
-            return null;
+            throw new MappingException(label, $"JSONPath '{path}' did not match only objects");
         }
     }
 
-    private string? ExtractArgumentsValue(string json, string? path)
+    private IReadOnlyList<JsonElement> SelectRequiredTokens(
+        string json,
+        string path,
+        string label)
     {
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            return null;
-        }
-
         try
         {
-            var token = _jsonPathService.SelectToken(json, path);
-            if (token == null)
+            var tokens = _jsonPathService.SelectTokens(json, path).ToList();
+            if (tokens.Count == 0)
             {
-                return null;
+                throw new MappingException(label, $"JSONPath '{path}' did not match any values");
             }
 
-            // If already a string, return it
-            if (token.Value.ValueKind == JsonValueKind.String)
-            {
-                return token.Value.GetString();
-            }
-
-            // If object or array, serialize to JSON string
-            return token.Value.GetRawText();
+            return tokens;
         }
-        catch
+        catch (MappingException)
         {
-            return null;
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new MappingException(label, $"JSONPath '{path}' could not be evaluated", ex);
         }
     }
 
-    private int? ExtractIntValue(string json, string? path)
+    private JsonElement SelectRequiredToken(string json, string path, string label)
     {
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            return null;
-        }
-
         try
         {
-            var token = _jsonPathService.SelectToken(json, path);
-            if (token == null)
+            var tokens = _jsonPathService.SelectTokens(json, path).Take(2).ToList();
+            return tokens.Count switch
             {
-                return null;
-            }
-
-            if (token.Value.ValueKind == JsonValueKind.Number && token.Value.TryGetInt32(out var value))
-            {
-                return value;
-            }
+                1 => tokens[0],
+                0 => throw new MappingException(
+                    label,
+                    $"JSONPath '{path}' did not match a value"),
+                _ => throw new MappingException(
+                    label,
+                    $"JSONPath '{path}' matched more than one value")
+            };
         }
-        catch
+        catch (MappingException)
         {
-            // Ignore
+            throw;
         }
-
-        return null;
+        catch (Exception ex)
+        {
+            throw new MappingException(label, $"JSONPath '{path}' could not be evaluated", ex);
+        }
     }
 
-    private long? ExtractLongValue(string json, string? path)
+    private string ExtractRequiredStringValue(string json, string path, string label)
     {
-        if (string.IsNullOrWhiteSpace(path))
+        var value = SelectRequiredToken(json, path, label);
+        if (value.ValueKind != JsonValueKind.String)
         {
-            return null;
+            throw new MappingException(label, $"JSONPath '{path}' did not match a string");
         }
 
-        try
-        {
-            var token = _jsonPathService.SelectToken(json, path);
-            if (token == null)
-            {
-                return null;
-            }
-
-            if (token.Value.ValueKind == JsonValueKind.Number && token.Value.TryGetInt64(out var value))
-            {
-                return value;
-            }
-        }
-        catch
-        {
-            // Ignore
-        }
-
-        return null;
+        return value.GetString()!;
     }
 
-    private decimal? ExtractDecimalValue(string json, string? path)
+    private string ExtractRequiredContentValue(string json, string path, string label)
     {
-        if (string.IsNullOrWhiteSpace(path))
+        return FormatContentValue(SelectRequiredToken(json, path, label));
+    }
+
+    private string ExtractRequiredArgumentsValue(string json, string path, string label)
+    {
+        var value = SelectRequiredToken(json, path, label);
+        return value.ValueKind == JsonValueKind.String
+            ? value.GetString()!
+            : value.GetRawText();
+    }
+
+    private string? ExtractOptionalStringValue(string json, string? path, string label)
+    {
+        if (path == null)
         {
             return null;
         }
 
+        var value = SelectOptionalToken(json, path, label);
+        if (value == null)
+        {
+            return null;
+        }
+
+        if (value.Value.ValueKind != JsonValueKind.String)
+        {
+            throw new MappingException(label, $"JSONPath '{path}' did not match a string");
+        }
+
+        return value.Value.GetString();
+    }
+
+    private string? ExtractOptionalIdValue(string json, string? path, string label)
+    {
+        if (path == null)
+        {
+            return null;
+        }
+
+        var value = SelectOptionalToken(json, path, label);
+        if (value == null)
+        {
+            return null;
+        }
+
+        return value.Value.ValueKind switch
+        {
+            JsonValueKind.String => value.Value.GetString(),
+            JsonValueKind.Number => value.Value.GetRawText(),
+            _ => throw new MappingException(
+                label,
+                $"JSONPath '{path}' did not match a string or number")
+        };
+    }
+
+    private Dictionary<string, object>? ExtractOptionalMetadataValue(
+        string json,
+        string? path,
+        string label)
+    {
+        if (path == null)
+        {
+            return null;
+        }
+
+        var value = SelectOptionalToken(json, path, label);
+        if (value == null)
+        {
+            return null;
+        }
+
+        if (value.Value.ValueKind != JsonValueKind.Object)
+        {
+            throw new MappingException(label, $"JSONPath '{path}' did not match an object");
+        }
+
+        return JsonSerializer.Deserialize<Dictionary<string, object>>(value.Value.GetRawText());
+    }
+
+    private JsonElement? SelectOptionalToken(string json, string path, string label)
+    {
         try
         {
-            var token = _jsonPathService.SelectToken(json, path);
-            if (token == null)
+            var tokens = _jsonPathService.SelectTokens(json, path).Take(2).ToList();
+            return tokens.Count switch
             {
-                return null;
-            }
-
-            if (token.Value.ValueKind == JsonValueKind.Number && token.Value.TryGetDecimal(out var value))
-            {
-                return value;
-            }
+                0 => null,
+                1 => tokens[0],
+                _ => throw new MappingException(
+                    label,
+                    $"JSONPath '{path}' matched more than one value")
+            };
         }
-        catch
+        catch (MappingException)
         {
-            // Ignore
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new MappingException(label, $"JSONPath '{path}' could not be evaluated", ex);
+        }
+    }
+
+    private static string FormatContentValue(JsonElement value)
+    {
+        if (value.ValueKind == JsonValueKind.String)
+        {
+            return value.GetString()!;
         }
 
-        return null;
+        if (value.ValueKind != JsonValueKind.Array)
+        {
+            return value.GetRawText();
+        }
+
+        return string.Join(
+            "\n",
+            value.EnumerateArray().Select(item =>
+                item.ValueKind == JsonValueKind.String
+                    ? item.GetString()!
+                    : item.GetRawText()));
+    }
+
+    private int? ExtractConfiguredIntValue(string json, string? path, string label)
+    {
+        if (path == null)
+        {
+            return null;
+        }
+
+        var token = SelectRequiredToken(json, path, label);
+        if (token.ValueKind == JsonValueKind.Number && token.TryGetInt32(out var value))
+        {
+            return value;
+        }
+
+        throw new MappingException(label, $"JSONPath '{path}' did not match a 32-bit integer");
+    }
+
+    private long? ExtractConfiguredLongValue(string json, string? path, string label)
+    {
+        if (path == null)
+        {
+            return null;
+        }
+
+        var token = SelectRequiredToken(json, path, label);
+        if (token.ValueKind == JsonValueKind.Number && token.TryGetInt64(out var value))
+        {
+            return value;
+        }
+
+        throw new MappingException(label, $"JSONPath '{path}' did not match a 64-bit integer");
+    }
+
+    private decimal? ExtractConfiguredDecimalValue(string json, string? path, string label)
+    {
+        if (path == null)
+        {
+            return null;
+        }
+
+        var token = SelectRequiredToken(json, path, label);
+        if (token.ValueKind == JsonValueKind.Number && token.TryGetDecimal(out var value))
+        {
+            return value;
+        }
+
+        throw new MappingException(label, $"JSONPath '{path}' did not match a decimal number");
     }
 
     private string? CapRawResponse(string responseJson)
@@ -410,17 +874,42 @@ public class MappingService : IMappingService
             return null;
         }
 
-        if (responseJson.Length > MaxRawResponseSize)
+        if (Encoding.UTF8.GetByteCount(responseJson) > MaxRawResponseSize)
         {
-            return responseJson.Substring(0, MaxRawResponseSize) + "\n... (truncated)";
+            const string suffix = "\n... (truncated)";
+            var payloadLimit = MaxRawResponseSize - Encoding.UTF8.GetByteCount(suffix);
+            var retainedBytes = 0;
+            var builder = new StringBuilder();
+            foreach (var rune in responseJson.EnumerateRunes())
+            {
+                if (retainedBytes + rune.Utf8SequenceLength > payloadLimit)
+                {
+                    break;
+                }
+
+                builder.Append(rune.ToString());
+                retainedBytes += rune.Utf8SequenceLength;
+            }
+
+            return builder.Append(suffix).ToString();
         }
 
         return responseJson;
     }
 
+    private sealed class MappingException(
+        string path,
+        string detail,
+        Exception? innerException = null)
+        : Exception($"Mapping failed at '{path}': {detail}", innerException)
+    {
+        public string Path { get; } = path;
+    }
+
     // MappingSpec CRUD operations
     public async Task<MappingSpec> SaveMappingSpecAsync(Guid endpointId, string name, string specJson)
     {
+        DeserializeAndValidateMappingSpec(specJson);
         var mappingSpec = new MappingSpec
         {
             Id = Guid.NewGuid(),
@@ -466,6 +955,7 @@ public class MappingService : IMappingService
         {
             throw new InvalidOperationException($"MappingSpec with ID {id} not found");
         }
+        DeserializeAndValidateMappingSpec(specJson);
 
         mappingSpec.Name = name;
         mappingSpec.SpecJson = specJson;
@@ -512,4 +1002,18 @@ public class MappingService : IMappingService
         _dbContext.MappingSpecs.Remove(mappingSpec);
         await _dbContext.SaveChangesAsync();
     }
+}
+
+public sealed class MappingSpecValidationException : Exception
+{
+    public MappingSpecValidationException(
+        string path,
+        string detail,
+        Exception? innerException = null)
+        : base($"Invalid mapping spec at '{path}': {detail}", innerException)
+    {
+        Path = path;
+    }
+
+    public string Path { get; }
 }

--- a/Promptly.Application/Services/MappingService.cs
+++ b/Promptly.Application/Services/MappingService.cs
@@ -185,12 +185,9 @@ public class MappingService : IMappingService
         }
         else if (element.ValueKind == JsonValueKind.Array)
         {
-            foreach (var item in element.EnumerateArray())
+            if (element.EnumerateArray().Any(ContainsDuplicateObjectProperty))
             {
-                if (ContainsDuplicateObjectProperty(item))
-                {
-                    return true;
-                }
+                return true;
             }
         }
         else if (element.ValueKind == JsonValueKind.String)
@@ -336,7 +333,7 @@ public class MappingService : IMappingService
             {
                 _jsonPathService.SelectToken("{}", path!);
             }
-            catch (Exception ex)
+            catch (InvalidOperationException ex)
             {
                 throw new MappingSpecValidationException(
                     label,
@@ -491,22 +488,21 @@ public class MappingService : IMappingService
             spec.ToolCalls.ItemsPath!,
             "toolCalls.itemsPath");
         RequireObjectItems(toolCallItems, spec.ToolCalls.ItemsPath!, "toolCalls.itemsPath");
-        var toolCalls = new List<ToolCall>(toolCallItems.Count);
-        foreach (var item in toolCallItems)
+        return toolCallItems.Select(item =>
         {
             var itemJson = item.GetRawText();
-            var name = ExtractRequiredStringValue(
-                itemJson,
-                spec.ToolCalls.NamePath,
-                "toolCalls.namePath");
-            var arguments = ExtractRequiredArgumentsValue(
-                itemJson,
-                spec.ToolCalls.ArgumentsPath,
-                "toolCalls.argumentsPath");
-            toolCalls.Add(new ToolCall { Name = name, ArgumentsJson = arguments });
-        }
-
-        return toolCalls;
+            return new ToolCall
+            {
+                Name = ExtractRequiredStringValue(
+                    itemJson,
+                    spec.ToolCalls.NamePath,
+                    "toolCalls.namePath"),
+                ArgumentsJson = ExtractRequiredArgumentsValue(
+                    itemJson,
+                    spec.ToolCalls.ArgumentsPath,
+                    "toolCalls.argumentsPath")
+            };
+        }).ToList();
     }
 
     private Usage? ExtractUsage(MappingSpecDefinition spec, string responseJson)
@@ -577,11 +573,10 @@ public class MappingService : IMappingService
             docItems,
             spec.RetrievedDocs.MetadataPath,
             "retrievedDocs.metadataPath");
-        var docs = new List<RetrievedDoc>(docItems.Count);
-        foreach (var item in docItems)
+        return docItems.Select(item =>
         {
             var itemJson = item.GetRawText();
-            docs.Add(new RetrievedDoc
+            return new RetrievedDoc
             {
                 Id = ExtractOptionalIdValue(
                     itemJson,
@@ -599,10 +594,8 @@ public class MappingService : IMappingService
                     itemJson,
                     spec.RetrievedDocs.MetadataPath,
                     "retrievedDocs.metadataPath")
-            });
-        }
-
-        return docs;
+            };
+        }).ToList();
     }
 
     private void RequireOptionalPathMatch(
@@ -651,7 +644,7 @@ public class MappingService : IMappingService
         {
             throw;
         }
-        catch (Exception ex)
+        catch (InvalidOperationException ex)
         {
             throw new MappingException(label, $"JSONPath '{path}' could not be evaluated", ex);
         }
@@ -677,7 +670,7 @@ public class MappingService : IMappingService
         {
             throw;
         }
-        catch (Exception ex)
+        catch (InvalidOperationException ex)
         {
             throw new MappingException(label, $"JSONPath '{path}' could not be evaluated", ex);
         }
@@ -793,7 +786,7 @@ public class MappingService : IMappingService
         {
             throw;
         }
-        catch (Exception ex)
+        catch (InvalidOperationException ex)
         {
             throw new MappingException(label, $"JSONPath '{path}' could not be evaluated", ex);
         }
@@ -887,7 +880,7 @@ public class MappingService : IMappingService
                     break;
                 }
 
-                builder.Append(rune.ToString());
+                builder.Append(rune);
                 retainedBytes += rune.Utf8SequenceLength;
             }
 

--- a/Promptly.Domain/ValueObjects/MappingSpecDefinition.cs
+++ b/Promptly.Domain/ValueObjects/MappingSpecDefinition.cs
@@ -2,7 +2,7 @@ namespace Promptly.Domain.ValueObjects;
 
 public record MappingSpecDefinition
 {
-    public int Version { get; init; } = 1;
+    public int? Version { get; init; }
     public MessagesMapping? Messages { get; init; }
     public ToolCallsMapping? ToolCalls { get; init; }
     public UsageMapping? Usage { get; init; }
@@ -12,21 +12,21 @@ public record MappingSpecDefinition
 
 public record MessagesMapping
 {
-    public required string ItemsPath { get; init; }
+    public string? ItemsPath { get; init; }
     public string RolePath { get; init; } = "$.role";
     public string ContentPath { get; init; } = "$.content";
 }
 
 public record ToolCallsMapping
 {
-    public required string ItemsPath { get; init; }
+    public string? ItemsPath { get; init; }
     public string NamePath { get; init; } = "$.name";
     public string ArgumentsPath { get; init; } = "$.arguments";
 }
 
 public record UsageMapping
 {
-    public required string ObjectPath { get; init; }
+    public string? ObjectPath { get; init; }
     public string? PromptTokensPath { get; init; }
     public string? CompletionTokensPath { get; init; }
     public string? TotalTokensPath { get; init; }
@@ -36,10 +36,10 @@ public record UsageMapping
 
 public record RetrievedDocsMapping
 {
-    public required string ItemsPath { get; init; }
+    public string? ItemsPath { get; init; }
     public string? IdPath { get; init; }
     public string? TitlePath { get; init; }
-    public required string ContentPath { get; init; }
+    public string? ContentPath { get; init; }
     public string? MetadataPath { get; init; }
 }
 

--- a/Promptly.Server/Controllers/MappingController.cs
+++ b/Promptly.Server/Controllers/MappingController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Promptly.Application.Interfaces;
 using Promptly.Application.Models;
+using Promptly.Application.Services;
 
 namespace Promptly.Server.Controllers;
 
@@ -110,7 +111,8 @@ public class MappingController : ControllerBase
             {
                 Success = result.Success,
                 PreviewTrace = result.Trace,
-                ErrorMessage = result.ErrorMessage
+                ErrorMessage = result.ErrorMessage,
+                ErrorPath = result.ErrorPath
             });
         }
         catch (Exception ex)
@@ -153,6 +155,10 @@ public class MappingController : ControllerBase
             };
 
             return CreatedAtAction(nameof(GetMappingSpec), new { id = mappingSpec.Id }, response);
+        }
+        catch (MappingSpecValidationException ex)
+        {
+            return BadRequest(new { message = ex.Message, errorPath = ex.Path });
         }
         catch (Exception ex)
         {
@@ -257,6 +263,10 @@ public class MappingController : ControllerBase
             };
 
             return Ok(response);
+        }
+        catch (MappingSpecValidationException ex)
+        {
+            return BadRequest(new { message = ex.Message, errorPath = ex.Path });
         }
         catch (InvalidOperationException ex)
         {

--- a/Promptly.Web/src/web/src/api/mapping.ts
+++ b/Promptly.Web/src/web/src/api/mapping.ts
@@ -30,6 +30,7 @@ interface ValidateMappingResponse {
   success: boolean;
   previewTrace?: CanonicalTrace | null;
   errorMessage?: string;
+  errorPath?: string;
 }
 
 interface CanonicalTrace {

--- a/Promptly.Worker/pyproject.toml
+++ b/Promptly.Worker/pyproject.toml
@@ -7,7 +7,6 @@ requires-python = "==3.11.*"
 dependencies = [
     "fastapi==0.141.1",
     "httpx==0.27.2",
-    "jsonpath-ng==1.7.0",
     "openai==1.54.3",
     "pydantic==2.9.2",
     "pyyaml==6.0.2",

--- a/Promptly.Worker/routers/mapping.py
+++ b/Promptly.Worker/routers/mapping.py
@@ -4,12 +4,20 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Callable
 from contextlib import suppress
-from typing import Annotated, Any, Literal, Self
+from decimal import Decimal, DecimalException, localcontext
+from typing import Annotated, Any, Literal, NamedTuple, Self
 
 from fastapi import APIRouter, HTTPException
-from jsonpath_ng import parse as parse_jsonpath  # type: ignore[import-untyped]
-from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    model_validator,
+)
 
 from llm import (
     LlmClient,
@@ -22,12 +30,49 @@ from llm import (
 router = APIRouter()
 _DOT_MEMBER = r"\.[A-Za-z_][A-Za-z0-9_]*"
 _INDEX_OR_WILDCARD = r"\[(?:0|[1-9][0-9]*|\*)\]"
-_DOUBLE_QUOTED_MEMBER = r'\["[^"\\\r\n]*"\]'
-_SINGLE_QUOTED_MEMBER = r"\['[^'\\\r\n]*'\]"
+_DOUBLE_QUOTED_MEMBER = r'\["[^"\\\x00-\x1f]*"\]'
+_SINGLE_QUOTED_MEMBER = r"\['[^'\\\x00-\x1f]*'\]"
 _COMPATIBLE_JSONPATH_PATTERN = (
     rf"^\$(?:{_DOT_MEMBER}|{_INDEX_OR_WILDCARD}|"
     rf"{_DOUBLE_QUOTED_MEMBER}|{_SINGLE_QUOTED_MEMBER})*$"
 )
+_INT32_MIN = -(2**31)
+_INT32_MAX = 2**31 - 1
+_INT64_MIN = -(2**63)
+_INT64_MAX = 2**63 - 1
+_DECIMAL_OVERFLOW_THRESHOLD = Decimal("79228162514264337593543950335.5")
+_MAX_JSON_DEPTH = 64
+_SAFE_EXPONENT_DIGITS = 9
+_MAX_SAFE_ARRAY_INDEX = "9007199254740991"
+_SIMPLE_MEMBER_CHARACTERS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
+)
+
+
+def _validate_jsonpath_index_bounds(path: str) -> str:
+    position = 1
+    while position < len(path):
+        if path[position] == ".":
+            position += 1
+            while position < len(path) and path[position] in _SIMPLE_MEMBER_CHARACTERS:
+                position += 1
+            continue
+
+        if path[position + 1] in {'"', "'"}:
+            position = path.index(path[position + 1] + "]", position + 2) + 2
+            continue
+
+        end = path.index("]", position + 1)
+        selector = path[position + 1 : end]
+        if selector != "*" and (
+            len(selector) > len(_MAX_SAFE_ARRAY_INDEX)
+            or (len(selector) == len(_MAX_SAFE_ARRAY_INDEX) and selector > _MAX_SAFE_ARRAY_INDEX)
+        ):
+            raise ValueError(f"array index must not exceed {_MAX_SAFE_ARRAY_INDEX}")
+        position = end + 1
+    return path
+
+
 JsonPath = Annotated[
     str,
     StringConstraints(
@@ -35,6 +80,7 @@ JsonPath = Annotated[
         min_length=1,
         pattern=_COMPATIBLE_JSONPATH_PATTERN,
     ),
+    AfterValidator(_validate_jsonpath_index_bounds),
 ]
 
 
@@ -104,7 +150,7 @@ class FallbackMapping(BaseModel):
 class MappingSpecSchema(BaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
-    version: Literal[1] = 1
+    version: Literal[1]
     messages: MessagesMapping | None = None
     tool_calls: ToolCallsMapping | None = Field(default=None, alias="toolCalls")
     usage: UsageMapping | None = None
@@ -127,19 +173,90 @@ class MappingProposeResponse(BaseModel):
     reason: str | None = None
 
 
+class _JsonNumber(str):
+    """A validated JSON number retained losslessly for .NET conversion parity."""
+
+
 def get_llm_client() -> LlmClient:
     """Router-level client seam for deterministic tests."""
 
     return create_llm_client()
 
 
+def _reject_nonstandard_json_constant(value: str) -> None:
+    raise ValueError(f"{value} is not valid JSON")
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON property {key!r}")
+        result[key] = value
+    return result
+
+
+def _validate_json_depth(value: str) -> None:
+    depth = 0
+    in_string = False
+    escaped = False
+    for character in value:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            continue
+        if character == '"':
+            in_string = True
+        elif character in "[{":
+            depth += 1
+            if depth > _MAX_JSON_DEPTH:
+                raise ValueError(f"JSON exceeds maximum depth {_MAX_JSON_DEPTH}")
+        elif character in "]}":
+            depth -= 1
+
+
+def _reject_surrogates(value: object) -> None:
+    if isinstance(value, str):
+        if any("\ud800" <= character <= "\udfff" for character in value):
+            raise ValueError("JSON contains an invalid Unicode surrogate")
+    elif isinstance(value, list):
+        for item in value:
+            _reject_surrogates(item)
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            _reject_surrogates(key)
+            _reject_surrogates(item)
+
+
+def _loads_strict_json(value: str, *, preserve_numbers: bool = False) -> object:
+    _validate_json_depth(value)
+    number_options = (
+        {"parse_int": _JsonNumber, "parse_float": _JsonNumber}
+        if preserve_numbers
+        else {"parse_float": Decimal}
+    )
+    parsed = json.loads(
+        value,
+        parse_constant=_reject_nonstandard_json_constant,
+        object_pairs_hook=_reject_duplicate_keys,
+        **number_options,
+    )
+    _reject_surrogates(parsed)
+    return parsed
+
+
 def _parse_input_json(value: str, field_name: str) -> object:
     try:
-        return json.loads(value)
-    except json.JSONDecodeError as exc:
+        return _loads_strict_json(value, preserve_numbers=True)
+    except (DecimalException, json.JSONDecodeError, RecursionError, ValueError) as exc:
+        position = f" at position {exc.pos}" if isinstance(exc, json.JSONDecodeError) else ""
         raise HTTPException(
             status_code=400,
-            detail=f"Invalid JSON in {field_name} at position {exc.pos}",
+            detail=f"Invalid JSON in {field_name}{position}",
         ) from exc
 
 
@@ -147,36 +264,200 @@ def _extract_json_object(value: str) -> object:
     text = value.strip()
     if text.startswith("```json") and text.endswith("```"):
         text = text[7:-3].strip()
-    return json.loads(text)
+    return _loads_strict_json(text)
+
+
+class _PathSegment(NamedTuple):
+    kind: Literal["member", "index", "wildcard"]
+    value: str | int | None = None
+
+
+def _parse_compatible_jsonpath(path: str) -> list[_PathSegment]:
+    segments: list[_PathSegment] = []
+    position = 1
+    while position < len(path):
+        if path[position] == ".":
+            end = position + 1
+            while end < len(path) and path[end] in _SIMPLE_MEMBER_CHARACTERS:
+                end += 1
+            segments.append(_PathSegment("member", path[position + 1 : end]))
+            position = end
+            continue
+
+        if path[position + 1] in {'"', "'"}:
+            end = path.index(path[position + 1] + "]", position + 2) + 1
+        else:
+            end = path.index("]", position)
+        selector = path[position + 1 : end]
+        if selector == "*":
+            segments.append(_PathSegment("wildcard"))
+        elif selector[0] in {'"', "'"}:
+            segments.append(_PathSegment("member", selector[1:-1]))
+        else:
+            segments.append(_PathSegment("index", int(selector)))
+        position = end + 1
+    return segments
+
+
+def _evaluate_jsonpath(path: str, value: object) -> list[object]:
+    matches = [value]
+    for segment in _parse_compatible_jsonpath(path):
+        next_matches: list[object] = []
+        for match in matches:
+            if segment.kind == "member" and isinstance(match, dict):
+                member = segment.value
+                if isinstance(member, str) and member in match:
+                    next_matches.append(match[member])
+            elif segment.kind == "index" and isinstance(match, list):
+                index = segment.value
+                if isinstance(index, int) and index < len(match):
+                    next_matches.append(match[index])
+            elif segment.kind == "wildcard":
+                if isinstance(match, list):
+                    next_matches.extend(match)
+                elif isinstance(match, dict):
+                    next_matches.extend(match.values())
+        matches = next_matches
+    return [match for match in matches if match is not None]
 
 
 def _select_required(path: str, value: object, label: str) -> list[object]:
-    try:
-        matches = [match.value for match in parse_jsonpath(path).find(value)]
-    except Exception as exc:
-        raise ValueError(f"{label} is not a valid JSONPath") from exc
+    matches = _evaluate_jsonpath(path, value)
     if not matches:
         raise ValueError(f"{label} does not match the sample response")
     return matches
 
 
-def _validate_relative_paths(
+def _select_singular(
+    value: object,
+    label: str,
+    path: str,
+) -> object:
+    matches = _evaluate_jsonpath(path, value)
+    if len(matches) != 1:
+        raise ValueError(f"{label} must match exactly one value")
+    return matches[0]
+
+
+def _validate_required_singular_paths(
     values: list[object],
-    paths: tuple[tuple[str, str | None], ...],
-    *,
-    require_every_value: bool,
+    paths: tuple[tuple[str, str, Callable[[object], bool] | None, str | None], ...],
 ) -> None:
-    for label, path in paths:
-        if path is None:
-            continue
-        try:
-            expression = parse_jsonpath(path)
-            matches_by_value = [bool(expression.find(value)) for value in values]
-        except Exception as exc:
-            raise ValueError(f"{label} is not a valid JSONPath") from exc
-        matches = all(matches_by_value) if require_every_value else any(matches_by_value)
+    for value in values:
+        for label, path, predicate, expected_shape in paths:
+            match = _select_singular(value, label, path)
+            if predicate is not None and not predicate(match):
+                raise ValueError(f"{label} must match {expected_shape}")
+
+
+def _validate_optional_singular_path(
+    values: list[object],
+    label: str,
+    path: str | None,
+    predicate: Callable[[object], bool] | None = None,
+    expected_shape: str | None = None,
+) -> None:
+    if path is None:
+        return
+    matched = False
+    for value in values:
+        matches = _evaluate_jsonpath(path, value)
+        if len(matches) > 1:
+            raise ValueError(f"{label} must match at most one value per item")
         if not matches:
-            raise ValueError(f"{label} does not match the sample response")
+            continue
+        matched = True
+        if predicate is not None and not predicate(matches[0]):
+            raise ValueError(f"{label} must match {expected_shape}")
+    if not matched:
+        raise ValueError(f"{label} does not match the sample response")
+
+
+def _is_int32(value: object) -> bool:
+    if not isinstance(value, _JsonNumber) or any(character in value for character in ".eE"):
+        return False
+    return _integer_token_in_range(value, _INT32_MIN, _INT32_MAX)
+
+
+def _is_int64(value: object) -> bool:
+    if not isinstance(value, _JsonNumber) or any(character in value for character in ".eE"):
+        return False
+    return _integer_token_in_range(value, _INT64_MIN, _INT64_MAX)
+
+
+def _integer_token_in_range(value: _JsonNumber, minimum: int, maximum: int) -> bool:
+    negative = value.startswith("-")
+    digits = value[1:] if negative else value
+    normalized = digits.lstrip("0") or "0"
+    limit = str(abs(minimum) if negative else maximum)
+    if len(normalized) != len(limit):
+        return len(normalized) < len(limit)
+    return normalized <= limit
+
+
+def _is_decimal_compatible(value: object) -> bool:
+    if not isinstance(value, _JsonNumber):
+        return False
+    mantissa, separator, exponent_text = value.lower().partition("e")
+    exponent_sign = exponent_text[:1] if exponent_text[:1] in "+-" else ""
+    exponent_digits = exponent_text[len(exponent_sign) :].lstrip("0") or "0"
+    normalized_exponent = exponent_sign + exponent_digits
+    exponent = (
+        int(normalized_exponent)
+        if separator and len(exponent_digits) <= _SAFE_EXPONENT_DIGITS
+        else None
+    )
+    if separator and exponent is None:
+        is_zero = all(character in "-0." for character in mantissa)
+        return is_zero or exponent_text.startswith("-")
+    digits = sum(character.isdigit() for character in value)
+    try:
+        with localcontext() as context:
+            context.prec = max(29, digits)
+            decimal_value = Decimal(value)
+    except DecimalException:
+        return False
+    return decimal_value.is_finite() and decimal_value.copy_abs() < _DECIMAL_OVERFLOW_THRESHOLD
+
+
+def _is_string(value: object) -> bool:
+    return isinstance(value, str) and not isinstance(value, _JsonNumber)
+
+
+def _is_json_number(value: object) -> bool:
+    return isinstance(value, _JsonNumber)
+
+
+def _is_document_id(value: object) -> bool:
+    return _is_string(value) or _is_json_number(value)
+
+
+def _select_object_items(path: str, value: object, label: str) -> list[object]:
+    items = _select_required(path, value, label)
+    if any(not isinstance(item, dict) for item in items):
+        raise ValueError(f"{label} must match objects")
+    return items
+
+
+def _validate_messages(spec: MessagesMapping, sample_response: object) -> None:
+    values = _select_object_items(spec.items_path, sample_response, "messages.itemsPath")
+    _validate_required_singular_paths(
+        values,
+        (
+            ("messages.rolePath", spec.role_path, _is_string, "a string"),
+            ("messages.contentPath", spec.content_path, None, None),
+        ),
+    )
+
+
+def _validate_fallback(spec: FallbackMapping, sample_response: object) -> None:
+    content = _select_singular(
+        sample_response,
+        "fallback.singleAssistantContentPath",
+        spec.single_assistant_content_path,
+    )
+    if not _is_string(content):
+        raise ValueError("fallback.singleAssistantContentPath must match a string")
 
 
 def _validate_mapping_against_sample(
@@ -184,71 +465,100 @@ def _validate_mapping_against_sample(
     sample_response: object,
 ) -> None:
     if spec.messages is not None:
-        values = _select_required(
-            spec.messages.items_path,
-            sample_response,
-            "messages.itemsPath",
-        )
-        _validate_relative_paths(
-            values,
-            (
-                ("messages.rolePath", spec.messages.role_path),
-                ("messages.contentPath", spec.messages.content_path),
-            ),
-            require_every_value=True,
-        )
+        try:
+            _validate_messages(spec.messages, sample_response)
+        except ValueError:
+            if spec.fallback is None:
+                raise
+            _validate_fallback(spec.fallback, sample_response)
+    elif spec.fallback is not None:
+        _validate_fallback(spec.fallback, sample_response)
     if spec.tool_calls is not None:
-        values = _select_required(
+        values = _select_object_items(
             spec.tool_calls.items_path,
             sample_response,
             "toolCalls.itemsPath",
         )
-        _validate_relative_paths(
+        _validate_required_singular_paths(
             values,
             (
-                ("toolCalls.namePath", spec.tool_calls.name_path),
-                ("toolCalls.argumentsPath", spec.tool_calls.arguments_path),
+                ("toolCalls.namePath", spec.tool_calls.name_path, _is_string, "a string"),
+                ("toolCalls.argumentsPath", spec.tool_calls.arguments_path, None, None),
             ),
-            require_every_value=True,
         )
     if spec.usage is not None:
-        values = _select_required(spec.usage.object_path, sample_response, "usage.objectPath")
-        _validate_relative_paths(
-            values,
+        usage = _select_singular(sample_response, "usage.objectPath", spec.usage.object_path)
+        if not isinstance(usage, dict):
+            raise ValueError("usage.objectPath must match an object")
+        for label, path, predicate, expected_shape in (
             (
-                ("usage.promptTokensPath", spec.usage.prompt_tokens_path),
-                ("usage.completionTokensPath", spec.usage.completion_tokens_path),
-                ("usage.totalTokensPath", spec.usage.total_tokens_path),
-                ("usage.costPath", spec.usage.cost_path),
-                ("usage.latencyMsPath", spec.usage.latency_ms_path),
+                "usage.promptTokensPath",
+                spec.usage.prompt_tokens_path,
+                _is_int32,
+                "a 32-bit integer",
             ),
-            require_every_value=True,
-        )
+            (
+                "usage.completionTokensPath",
+                spec.usage.completion_tokens_path,
+                _is_int32,
+                "a 32-bit integer",
+            ),
+            (
+                "usage.totalTokensPath",
+                spec.usage.total_tokens_path,
+                _is_int32,
+                "a 32-bit integer",
+            ),
+            ("usage.costPath", spec.usage.cost_path, _is_decimal_compatible, "a decimal number"),
+            (
+                "usage.latencyMsPath",
+                spec.usage.latency_ms_path,
+                _is_int64,
+                "a 64-bit integer",
+            ),
+        ):
+            if path is None:
+                continue
+            value = _select_singular(usage, label, path)
+            if not predicate(value):
+                raise ValueError(f"{label} must match {expected_shape}")
     if spec.retrieved_docs is not None:
-        values = _select_required(
+        values = _select_object_items(
             spec.retrieved_docs.items_path,
             sample_response,
             "retrievedDocs.itemsPath",
         )
-        _validate_relative_paths(
-            values,
-            (("retrievedDocs.contentPath", spec.retrieved_docs.content_path),),
-            require_every_value=True,
-        )
-        _validate_relative_paths(
+        _validate_required_singular_paths(
             values,
             (
-                ("retrievedDocs.idPath", spec.retrieved_docs.id_path),
-                ("retrievedDocs.titlePath", spec.retrieved_docs.title_path),
-                ("retrievedDocs.metadataPath", spec.retrieved_docs.metadata_path),
+                (
+                    "retrievedDocs.contentPath",
+                    spec.retrieved_docs.content_path,
+                    _is_string,
+                    "a string",
+                ),
             ),
-            require_every_value=False,
         )
-    if spec.fallback is not None:
-        _select_required(
-            spec.fallback.single_assistant_content_path,
-            sample_response,
-            "fallback.singleAssistantContentPath",
+        _validate_optional_singular_path(
+            values,
+            "retrievedDocs.metadataPath",
+            spec.retrieved_docs.metadata_path,
+            lambda value: isinstance(value, dict),
+            "an object",
+        )
+        _validate_optional_singular_path(
+            values,
+            "retrievedDocs.idPath",
+            spec.retrieved_docs.id_path,
+            _is_document_id,
+            "a string or number",
+        )
+        _validate_optional_singular_path(
+            values,
+            "retrievedDocs.titlePath",
+            spec.retrieved_docs.title_path,
+            _is_string,
+            "a string",
         )
 
 
@@ -275,7 +585,7 @@ itemsPath; usage requires objectPath; fallback may use
 singleAssistantContentPath. Do not invent data or return prose."""
     user_prompt = (
         "Analyze this sample response and propose a MappingSpec:\n"
-        f"{json.dumps(sample_response, indent=2)}\n\n"
+        f"{request.sample_response_json}\n\n"
         "Optional sample request:\n"
         f"{request.sample_request_json or 'Not provided'}\n\n"
         "Hints:\n"

--- a/Promptly.Worker/tests/test_mapping.py
+++ b/Promptly.Worker/tests/test_mapping.py
@@ -18,6 +18,33 @@ def client() -> TestClient:
     return TestClient(create_app())
 
 
+def _propose(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    spec: dict[str, Any] | str,
+    sample: object | str,
+) -> Any:
+    content = spec if isinstance(spec, str) else json.dumps(spec)
+    sample_json = sample if isinstance(sample, str) else json.dumps(sample, ensure_ascii=False)
+    monkeypatch.setattr(mapping, "get_llm_client", lambda: FakeLlmClient(content))
+    return client.post(
+        "/mapping/propose",
+        json={"sample_response_json": sample_json},
+    )
+
+
+def _assert_safe_502(response: Any) -> None:
+    assert response.status_code == 502
+    assert response.json() == {
+        "detail": {
+            "error": {
+                "message": "Failed to propose mapping",
+                "details": "The LLM provider returned an invalid response",
+            }
+        }
+    }
+
+
 def test_propose_mapping_returns_structured_provider_result(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -134,6 +161,500 @@ def test_propose_mapping_validates_every_supported_section_against_the_sample(
     assert response.status_code == 200
     assert response.json()["mappingSpec"]["toolCalls"]["itemsPath"] == "$.tool_calls[*]"
     assert response.json()["mappingSpec"]["retrievedDocs"]["contentPath"] == "$.content"
+
+
+@pytest.mark.parametrize(
+    ("metric_path", "value"),
+    [
+        ("promptTokensPath", -(2**31)),
+        ("completionTokensPath", 2**31 - 1),
+        ("totalTokensPath", 0),
+        ("costPath", 79228162514264337593543950335),
+        ("latencyMsPath", -(2**63)),
+        ("latencyMsPath", 2**63 - 1),
+    ],
+)
+def test_propose_mapping_accepts_server_compatible_usage_value_boundaries(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    metric_path: str,
+    value: object,
+) -> None:
+    content = json.dumps(
+        {
+            "version": 1,
+            "usage": {
+                "objectPath": "$.usage",
+                metric_path: "$.value",
+            },
+        }
+    )
+    monkeypatch.setattr(mapping, "get_llm_client", lambda: FakeLlmClient(content))
+    sample = {"usage": {"value": value}}
+
+    response = client.post(
+        "/mapping/propose",
+        json={"sample_response_json": json.dumps(sample)},
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    ("metric_path", "invalid_value"),
+    [
+        ("promptTokensPath", True),
+        ("completionTokensPath", 2**31),
+        ("totalTokensPath", 1.0),
+        ("latencyMsPath", -(2**63) - 1),
+        ("latencyMsPath", 1.0),
+        ("costPath", True),
+        ("costPath", "0.2"),
+        ("costPath", 79228162514264337593543950336),
+    ],
+)
+def test_propose_mapping_rejects_any_server_incompatible_usage_match(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    metric_path: str,
+    invalid_value: object,
+) -> None:
+    content = json.dumps(
+        {
+            "version": 1,
+            "usage": {
+                "objectPath": "$.usage",
+                metric_path: "$.value",
+            },
+        }
+    )
+    monkeypatch.setattr(mapping, "get_llm_client", lambda: FakeLlmClient(content))
+
+    response = client.post(
+        "/mapping/propose",
+        json={"sample_response_json": json.dumps({"usage": {"value": invalid_value}})},
+    )
+
+    assert response.status_code == 502
+    assert response.json() == {
+        "detail": {
+            "error": {
+                "message": "Failed to propose mapping",
+                "details": "The LLM provider returned an invalid response",
+            }
+        }
+    }
+
+
+@pytest.mark.parametrize("invalid_metadata", ["source", [], 1, True])
+def test_propose_mapping_rejects_any_non_object_metadata_match(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    invalid_metadata: object,
+) -> None:
+    content = json.dumps(
+        {
+            "version": 1,
+            "retrievedDocs": {
+                "itemsPath": "$.documents[*]",
+                "contentPath": "$.content",
+                "metadataPath": "$.metadata",
+            },
+        }
+    )
+    monkeypatch.setattr(mapping, "get_llm_client", lambda: FakeLlmClient(content))
+    sample = {
+        "documents": [
+            {"content": "first", "metadata": {"source": "valid"}},
+            {"content": "second", "metadata": invalid_metadata},
+        ]
+    }
+
+    response = client.post(
+        "/mapping/propose",
+        json={"sample_response_json": json.dumps(sample)},
+    )
+
+    assert response.status_code == 502
+    assert response.json()["detail"]["error"] == {
+        "message": "Failed to propose mapping",
+        "details": "The LLM provider returned an invalid response",
+    }
+
+
+@pytest.mark.parametrize(
+    ("path", "sample"),
+    [
+        ("$[*].content", {"first": {"content": "one"}}),
+        ('$["a]b"]', {"a]b": "one"}),
+        ("$['c]d']", {"c]d": "one"}),
+        ('$["apostrophe\'s"]', {"apostrophe's": "one"}),
+        ("$['double\"quote']", {'double"quote': "one"}),
+        ('$["[9007199254740992]"]', {"[9007199254740992]": "one"}),
+    ],
+)
+def test_propose_mapping_matches_jsonpath_net_object_and_quoted_member_semantics(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+    sample: object,
+) -> None:
+    response = _propose(
+        client,
+        monkeypatch,
+        {"version": 1, "fallback": {"singleAssistantContentPath": path}},
+        sample,
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        '$["tab\tkey"]',
+        "$['control\x01key']",
+        '$["nul\x00key"]',
+        "$['unit-separator\x1fkey']",
+    ],
+)
+def test_propose_mapping_rejects_control_characters_in_quoted_members(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+) -> None:
+    response = _propose(
+        client,
+        monkeypatch,
+        {"version": 1, "fallback": {"singleAssistantContentPath": path}},
+        {"answer": "unused"},
+    )
+
+    _assert_safe_502(response)
+
+
+def test_propose_mapping_accepts_the_maximum_safe_array_index_before_fallback(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _propose(
+        client,
+        monkeypatch,
+        {
+            "version": 1,
+            "messages": {"itemsPath": "$[9007199254740991]"},
+            "fallback": {"singleAssistantContentPath": "$.answer"},
+        },
+        {"answer": "fallback"},
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize("index", ["9007199254740992", "9" * 5000])
+def test_propose_mapping_rejects_unsafe_dormant_messages_index_before_fallback(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    index: str,
+) -> None:
+    response = _propose(
+        client,
+        monkeypatch,
+        {
+            "version": 1,
+            "messages": {"itemsPath": f"$[{index}]"},
+            "fallback": {"singleAssistantContentPath": "$.answer"},
+        },
+        {"answer": "fallback"},
+    )
+
+    _assert_safe_502(response)
+
+
+@pytest.mark.parametrize(
+    ("path", "sample"),
+    [
+        ("$[0]", '"abc"'),
+        ("$[*]", '"abc"'),
+        ("$[0]", {"0": "value"}),
+        ("$[*]", 1),
+        ("$.answer", {"answer": None}),
+    ],
+)
+def test_propose_mapping_rejects_jsonpath_net_nonmatches_and_omits_null(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+    sample: object,
+) -> None:
+    response = _propose(
+        client,
+        monkeypatch,
+        {"version": 1, "fallback": {"singleAssistantContentPath": path}},
+        sample,
+    )
+
+    _assert_safe_502(response)
+
+
+def test_propose_mapping_accepts_null_optional_metadata_as_absent(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _propose(
+        client,
+        monkeypatch,
+        {
+            "version": 1,
+            "retrievedDocs": {
+                "itemsPath": "$.documents[*]",
+                "contentPath": "$.content",
+                "metadataPath": "$.metadata",
+            },
+        },
+        {
+            "documents": [
+                {"content": "one", "metadata": None},
+                {"content": "two", "metadata": {"source": "valid"}},
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+
+
+def test_propose_mapping_does_not_evaluate_fallback_after_messages_succeed(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _propose(
+        client,
+        monkeypatch,
+        {
+            "version": 1,
+            "messages": {"itemsPath": "$.messages[*]"},
+            "fallback": {"singleAssistantContentPath": "$.missing"},
+        },
+        {"messages": [{"role": "assistant", "content": "primary"}]},
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "messages",
+    [
+        [],
+        [{"role": "assistant", "content": "partial"}, {"role": "assistant"}],
+        [{"role": 1, "content": "wrong role type"}],
+    ],
+)
+def test_propose_mapping_accepts_valid_fallback_after_messages_fail(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    messages: list[object],
+) -> None:
+    response = _propose(
+        client,
+        monkeypatch,
+        {
+            "version": 1,
+            "messages": {"itemsPath": "$.messages[*]"},
+            "fallback": {"singleAssistantContentPath": "$.answer"},
+        },
+        {"messages": messages, "answer": "fallback"},
+    )
+
+    assert response.status_code == 200
+
+
+def test_propose_mapping_rejects_when_messages_and_fallback_both_fail(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _propose(
+        client,
+        monkeypatch,
+        {
+            "version": 1,
+            "messages": {"itemsPath": "$.messages[*]"},
+            "fallback": {"singleAssistantContentPath": "$.answer"},
+        },
+        {"messages": [{"role": "assistant"}], "answer": 42},
+    )
+
+    _assert_safe_502(response)
+
+
+@pytest.mark.parametrize("fallback", [42, True, [], {}, None])
+def test_propose_mapping_requires_string_fallback_content(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    fallback: object,
+) -> None:
+    response = _propose(
+        client,
+        monkeypatch,
+        {"version": 1, "fallback": {"singleAssistantContentPath": "$.answer"}},
+        {"answer": fallback},
+    )
+
+    _assert_safe_502(response)
+
+
+@pytest.mark.parametrize(
+    ("section", "sample"),
+    [
+        (
+            {"messages": {"itemsPath": "$.items[*]"}},
+            {"items": [{"role": 1, "content": "content"}]},
+        ),
+        (
+            {"toolCalls": {"itemsPath": "$.items[*]"}},
+            {"items": [{"name": 1, "arguments": {}}]},
+        ),
+        (
+            {"retrievedDocs": {"itemsPath": "$.items[*]", "contentPath": "$.content"}},
+            {"items": [{"content": 1}]},
+        ),
+    ],
+)
+def test_propose_mapping_requires_string_canonical_fields(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    section: dict[str, Any],
+    sample: dict[str, Any],
+) -> None:
+    response = _propose(client, monkeypatch, {"version": 1, **section}, sample)
+
+    _assert_safe_502(response)
+
+
+@pytest.mark.parametrize(
+    ("section", "sample"),
+    [
+        ({"messages": {"itemsPath": "$.items[*]"}}, {"items": ["message"]}),
+        ({"toolCalls": {"itemsPath": "$.items[*]"}}, {"items": [1]}),
+        (
+            {"retrievedDocs": {"itemsPath": "$.items[*]", "contentPath": "$.content"}},
+            {"items": [True]},
+        ),
+        (
+            {"usage": {"objectPath": "$.usage", "totalTokensPath": "$.total"}},
+            {"usage": [{"total": 1}]},
+        ),
+    ],
+)
+def test_propose_mapping_requires_object_items_and_usage_object(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    section: dict[str, Any],
+    sample: dict[str, Any],
+) -> None:
+    response = _propose(client, monkeypatch, {"version": 1, **section}, sample)
+
+    _assert_safe_502(response)
+
+
+@pytest.mark.parametrize(
+    ("section", "sample"),
+    [
+        (
+            {"usage": {"objectPath": "$.usages[*]", "totalTokensPath": "$.total"}},
+            {"usages": [{"total": 1}, {"total": 2}]},
+        ),
+        (
+            {"usage": {"objectPath": "$.usage", "totalTokensPath": "$.values[*]"}},
+            {"usage": {"values": [1, 2]}},
+        ),
+        (
+            {
+                "messages": {
+                    "itemsPath": "$.items[*]",
+                    "rolePath": "$.roles[*]",
+                }
+            },
+            {"items": [{"roles": ["assistant", "user"], "content": "hello"}]},
+        ),
+        (
+            {
+                "retrievedDocs": {
+                    "itemsPath": "$.items[*]",
+                    "contentPath": "$.content",
+                    "idPath": "$.ids[*]",
+                }
+            },
+            {"items": [{"content": "doc", "ids": [1, 2]}]},
+        ),
+    ],
+)
+def test_propose_mapping_rejects_multiple_matches_for_singular_paths(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    section: dict[str, Any],
+    sample: dict[str, Any],
+) -> None:
+    response = _propose(client, monkeypatch, {"version": 1, **section}, sample)
+
+    _assert_safe_502(response)
+
+
+@pytest.mark.parametrize("document_id", ["doc-1", 1, 1.25])
+def test_propose_mapping_accepts_string_or_numeric_document_id(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    document_id: object,
+) -> None:
+    response = _propose(
+        client,
+        monkeypatch,
+        {
+            "version": 1,
+            "retrievedDocs": {
+                "itemsPath": "$.items[*]",
+                "contentPath": "$.content",
+                "idPath": "$.id",
+                "titlePath": "$.title",
+            },
+        },
+        {"items": [{"content": "doc", "id": document_id, "title": "title"}]},
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        ("idPath", True),
+        ("idPath", {}),
+        ("idPath", []),
+        ("titlePath", 1),
+        ("titlePath", False),
+        ("titlePath", {}),
+    ],
+)
+def test_propose_mapping_rejects_invalid_document_id_or_title_type(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+    value: object,
+) -> None:
+    response = _propose(
+        client,
+        monkeypatch,
+        {
+            "version": 1,
+            "retrievedDocs": {
+                "itemsPath": "$.items[*]",
+                "contentPath": "$.content",
+                path: "$.value",
+            },
+        },
+        {"items": [{"content": "doc", "value": value}]},
+    )
+
+    _assert_safe_502(response)
 
 
 def test_propose_mapping_accepts_the_cross_runtime_jsonpath_subset(
@@ -271,6 +792,8 @@ def test_propose_mapping_requires_mandatory_paths_on_every_selected_item(
     "content",
     [
         '{"version":1}',
+        '{"fallback":{"singleAssistantContentPath":"$.answer"}}',
+        '{"version":null,"fallback":{"singleAssistantContentPath":"$.answer"}}',
         '{"version":1,"fallback":{"singleAssistantContentPath":"   "}}',
         '{"version":1,"fallback":{"singleAssistantContentPath":"$["}}',
         '{"version":1,"fallback":{"singleAssistantContentPath":"$.missing"}}',
@@ -297,10 +820,36 @@ def test_propose_mapping_rejects_empty_invalid_or_nonmatching_specs(
     ("payload", "field"),
     [
         ({"sample_response_json": "{broken"}, "sample_response_json"),
+        ({"sample_response_json": '{"value":NaN}'}, "sample_response_json"),
+        ({"sample_response_json": '{"value":Infinity}'}, "sample_response_json"),
+        ({"sample_response_json": '{"value":-Infinity}'}, "sample_response_json"),
+        ({"sample_response_json": '{"answer":1,"answer":2}'}, "sample_response_json"),
+        ({"sample_response_json": '{"answer":"\\ud800"}'}, "sample_response_json"),
         (
             {
                 "sample_response_json": "{}",
                 "sample_request_json": "{broken",
+            },
+            "sample_request_json",
+        ),
+        (
+            {
+                "sample_response_json": "{}",
+                "sample_request_json": '{"value":NaN}',
+            },
+            "sample_request_json",
+        ),
+        (
+            {
+                "sample_response_json": "{}",
+                "sample_request_json": '{"value":1,"value":2}',
+            },
+            "sample_request_json",
+        ),
+        (
+            {
+                "sample_response_json": "{}",
+                "sample_request_json": '{"value":"\\ud800"}',
             },
             "sample_request_json",
         ),
@@ -317,7 +866,108 @@ def test_propose_mapping_rejects_malformed_sample_json(
     assert field in str(response.json()["detail"])
 
 
-@pytest.mark.parametrize("content", [None, "not-json", "```json\n{broken\n```"])
+def test_propose_mapping_matches_system_text_json_depth_limit(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec = {"version": 1, "fallback": {"singleAssistantContentPath": "$.answer"}}
+    accepted = '{"answer":"ok","nested":' + "[" * 63 + "0" + "]" * 63 + "}"
+    rejected = '{"answer":"ok","nested":' + "[" * 64 + "0" + "]" * 64 + "}"
+
+    accepted_response = _propose(client, monkeypatch, spec, accepted)
+    rejected_response = _propose(client, monkeypatch, spec, rejected)
+
+    assert accepted_response.status_code == 200
+    assert rejected_response.status_code == 400
+
+
+def test_propose_mapping_accepts_unrelated_valid_number_with_extreme_exponent(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _propose(
+        client,
+        monkeypatch,
+        {"version": 1, "fallback": {"singleAssistantContentPath": "$.answer"}},
+        '{"answer":"ok","unrelated":1e-999999999999999999999}',
+    )
+
+    assert response.status_code == 200
+
+
+def test_propose_mapping_accepts_unrelated_integer_beyond_python_digit_limit(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _propose(
+        client,
+        monkeypatch,
+        {"version": 1, "fallback": {"singleAssistantContentPath": "$.answer"}},
+        '{"answer":"ok","unrelated":' + "9" * 5000 + "}",
+    )
+
+    assert response.status_code == 200
+
+
+def test_propose_mapping_preserves_exact_sample_literals_in_provider_prompt(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sample = '{"usage":{"cost":7.9228162514264337593543950335e28}}'
+    llm = FakeLlmClient('{"version":1,"usage":{"objectPath":"$.usage","costPath":"$.cost"}}')
+    monkeypatch.setattr(mapping, "get_llm_client", lambda: llm)
+
+    response = client.post(
+        "/mapping/propose",
+        json={"sample_response_json": sample},
+    )
+
+    assert response.status_code == 200
+    assert sample in llm.completions.calls[0]["messages"][1]["content"]
+
+
+@pytest.mark.parametrize(
+    ("sample", "expected_status"),
+    [
+        ('{"usage":{"cost":7.9228162514264337593543950335e28}}', 200),
+        ('{"usage":{"cost":79228162514264337593543950335.4}}', 200),
+        ('{"usage":{"cost":79228162514264337593543950335.5}}', 502),
+        ('{"usage":{"cost":7.9228162514264337593543950336e28}}', 502),
+        ('{"usage":{"cost":1e-999999999999999999999}}', 200),
+        ('{"usage":{"cost":1e999999999999999999999}}', 502),
+        ('{"usage":{"cost":0e999999999999999999999}}', 200),
+        ('{"usage":{"cost":-0e+999999999999999999999}}', 200),
+        ('{"usage":{"cost":1e+0000000001}}', 200),
+    ],
+)
+def test_propose_mapping_matches_dotnet_decimal_boundaries_without_rounding_input(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    sample: str,
+    expected_status: int,
+) -> None:
+    response = _propose(
+        client,
+        monkeypatch,
+        {"version": 1, "usage": {"objectPath": "$.usage", "costPath": "$.cost"}},
+        sample,
+    )
+
+    assert response.status_code == expected_status
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        None,
+        "not-json",
+        "```json\n{broken\n```",
+        '{"version":NaN,"fallback":{"singleAssistantContentPath":"$.answer"}}',
+        '{"version":1,"fallback":{"singleAssistantContentPath":"$.answer"},"x":1,"x":2}',
+        '{"version":1,"fallback":{"singleAssistantContentPath":"$.\\ud800"}}',
+        "[" * 65 + "0" + "]" * 65,
+    ],
+)
 def test_propose_mapping_handles_invalid_provider_output_without_leaking_details(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/Promptly.Worker/uv.lock
+++ b/Promptly.Worker/uv.lock
@@ -386,18 +386,6 @@ wheels = [
 ]
 
 [[package]]
-name = "jsonpath-ng"
-version = "1.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ply" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/86/08646239a313f895186ff0a4573452038eed8c86f54380b3ebac34d32fb2/jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c", size = 37838, upload-time = "2024-10-11T15:41:42.404Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/5a/73ecb3d82f8615f32ccdadeb9356726d6cae3a4bbc840b437ceb95708063/jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6", size = 30105, upload-time = "2024-11-20T17:58:30.418Z" },
-]
-
-[[package]]
 name = "librt"
 version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -624,22 +612,12 @@ wheels = [
 ]
 
 [[package]]
-name = "ply"
-version = "3.11"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
-]
-
-[[package]]
 name = "promptly-worker"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
-    { name = "jsonpath-ng" },
     { name = "openai" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -662,7 +640,6 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = "==0.141.1" },
     { name = "httpx", specifier = "==0.27.2" },
-    { name = "jsonpath-ng", specifier = "==1.7.0" },
     { name = "openai", specifier = "==1.54.3" },
     { name = "pydantic", specifier = "==2.9.2" },
     { name = "pyyaml", specifier = "==6.0.2" },

--- a/tests/Promptly.Application.UnitTests/MappingControllerValidationTests.cs
+++ b/tests/Promptly.Application.UnitTests/MappingControllerValidationTests.cs
@@ -1,0 +1,192 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Promptly.Application.Interfaces;
+using Promptly.Application.Models;
+using Promptly.Application.Services;
+using Promptly.Domain.Entities;
+using Promptly.Domain.ValueObjects;
+using Promptly.Server.Controllers;
+
+namespace Promptly.Application.UnitTests;
+
+public sealed class MappingControllerValidationTests
+{
+    [Theory]
+    [InlineData("create")]
+    [InlineData("update")]
+    public async Task Persistence_routes_return_structured_bad_requests_for_invalid_specs(
+        string operation)
+    {
+        var endpoint = new Endpoint
+        {
+            Id = Guid.NewGuid(),
+            EnvironmentId = Guid.NewGuid(),
+            Name = "chat",
+            Path = "/chat"
+        };
+        var controller = CreateController(
+            endpoint,
+            new ValidationMappingService());
+
+        var action = operation == "create"
+            ? await controller.CreateMappingSpec(
+                endpoint.Id,
+                new CreateMappingSpecRequest { Name = "invalid", SpecJson = "{}" })
+            : await controller.UpdateMappingSpec(
+                Guid.NewGuid(),
+                new UpdateMappingSpecRequest { Name = "invalid", SpecJson = "{}" });
+
+        var result = Assert.IsType<BadRequestObjectResult>(action);
+        using var body = JsonDocument.Parse(JsonSerializer.Serialize(result.Value));
+        Assert.Equal(
+            "fallback.singleAssistantContentPath",
+            body.RootElement.GetProperty("errorPath").GetString());
+        Assert.Contains(
+            "Invalid mapping spec",
+            body.RootElement.GetProperty("message").GetString(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Validate_route_preserves_the_structured_mapping_error_path()
+    {
+        var endpoint = new Endpoint
+        {
+            Id = Guid.NewGuid(),
+            EnvironmentId = Guid.NewGuid(),
+            Name = "chat",
+            Path = "/chat"
+        };
+        var controller = CreateController(
+            endpoint,
+            new ValidationMappingService(new MappingResult
+            {
+                Success = false,
+                ErrorMessage = "Mapping failed at 'messages.itemsPath': no values",
+                ErrorPath = "messages.itemsPath"
+            }));
+
+        var action = await controller.ValidateMapping(
+            endpoint.Id,
+            new ValidateMappingRequest
+            {
+                MappingSpecJson = "{}",
+                SampleResponseJson = "{}"
+            });
+
+        var result = Assert.IsType<OkObjectResult>(action);
+        var response = Assert.IsType<ValidateMappingResponse>(result.Value);
+        Assert.False(response.Success);
+        Assert.Equal("messages.itemsPath", response.ErrorPath);
+    }
+
+    private static MappingController CreateController(
+        Endpoint endpoint,
+        IMappingService mappingService) =>
+        new(
+            mappingService,
+            new StubEndpointService(endpoint),
+            new UnusedPythonEvalClient(),
+            NullLogger<MappingController>.Instance);
+
+    private sealed class ValidationMappingService(MappingResult? validationResult = null)
+        : IMappingService
+    {
+        public Task<MappingResult> ValidateMappingAsync(
+            string mappingSpecJson,
+            string sampleResponseJson) =>
+            Task.FromResult(validationResult ?? new MappingResult { Success = true });
+
+        public Task<MappingSpec> SaveMappingSpecAsync(
+            Guid endpointId,
+            string name,
+            string specJson) =>
+            throw InvalidSpec();
+
+        public Task<MappingSpec> UpdateMappingSpecAsync(
+            Guid id,
+            string name,
+            string specJson) =>
+            throw InvalidSpec();
+
+        public Task<MappingResult> ApplyMappingAsync(string mappingSpecJson, string responseJson) =>
+            throw new NotSupportedException();
+
+        public Task<List<MappingSpec>> GetMappingSpecsByEndpointAsync(Guid endpointId) =>
+            throw new NotSupportedException();
+
+        public Task<MappingSpec?> GetMappingSpecByIdAsync(Guid id) =>
+            throw new NotSupportedException();
+
+        public Task<MappingSpec?> GetDefaultMappingAsync(Guid endpointId) =>
+            throw new NotSupportedException();
+
+        public Task SetDefaultMappingAsync(Guid id) =>
+            throw new NotSupportedException();
+
+        public Task DeleteMappingSpecAsync(Guid id) =>
+            throw new NotSupportedException();
+
+        private static MappingSpecValidationException InvalidSpec() =>
+            new(
+                "fallback.singleAssistantContentPath",
+                "a non-empty JSONPath is required");
+    }
+
+    private sealed class StubEndpointService(Endpoint endpoint) : IEndpointService
+    {
+        public Task<Endpoint?> GetEndpointByIdAsync(Guid endpointId) =>
+            Task.FromResult<Endpoint?>(endpointId == endpoint.Id ? endpoint : null);
+
+        public Task<IEnumerable<Endpoint>> GetEndpointsByEnvironmentAsync(Guid environmentId) =>
+            throw new NotSupportedException();
+
+        public Task<Endpoint> CreateEndpointAsync(
+            Guid environmentId,
+            string name,
+            string path,
+            string httpMethod,
+            int timeoutSeconds) =>
+            throw new NotSupportedException();
+
+        public Task<Endpoint?> UpdateEndpointAsync(
+            Guid endpointId,
+            string name,
+            string path,
+            string httpMethod,
+            int timeoutSeconds) =>
+            throw new NotSupportedException();
+
+        public Task<bool> DeleteEndpointAsync(Guid endpointId) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class UnusedPythonEvalClient : IPythonEvalClient
+    {
+        public Task<MappingProposalResult> ProposeMappingAsync(
+            string sampleResponse,
+            string? sampleRequest = null,
+            Dictionary<string, object>? hints = null,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<EvaluationResult> EvaluateLlmJudgeAsync(
+            string rubric,
+            double minScore,
+            CanonicalTrace trace,
+            string? model = null,
+            string? provider = null,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<EvaluationResult> EvaluateGroundednessAsync(
+            double minScore,
+            CanonicalTrace trace,
+            List<RetrievedDoc> docs,
+            string? model = null,
+            string? provider = null,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+}

--- a/tests/Promptly.Application.UnitTests/MappingServiceTests.cs
+++ b/tests/Promptly.Application.UnitTests/MappingServiceTests.cs
@@ -1,0 +1,769 @@
+using System.Text.Json;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Promptly.Application.Data;
+using Promptly.Application.Interfaces;
+using Promptly.Application.Services;
+using Promptly.Infrastructure.Services;
+
+namespace Promptly.Application.UnitTests;
+
+public sealed class MappingServiceTests
+{
+    [Fact]
+    public async Task ApplyMappingAsync_maps_the_complete_camelCase_schema_1_contract()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(
+            """
+            {
+              "version": 1,
+              "messages": {
+                "itemsPath": "$.choices[*].message",
+                "rolePath": "$.role",
+                "contentPath": "$.content"
+              },
+              "toolCalls": {
+                "itemsPath": "$.tool_calls[*]",
+                "namePath": "$.function.name",
+                "argumentsPath": "$.function.arguments"
+              },
+              "usage": {
+                "objectPath": "$.usage",
+                "promptTokensPath": "$.prompt_tokens",
+                "completionTokensPath": "$.completion_tokens",
+                "totalTokensPath": "$.total_tokens",
+                "costPath": "$.cost",
+                "latencyMsPath": "$.latency_ms"
+              },
+              "retrievedDocs": {
+                "itemsPath": "$.documents[*]",
+                "idPath": "$.id",
+                "titlePath": "$.title",
+                "contentPath": "$.content",
+                "metadataPath": "$.metadata"
+              },
+              "fallback": { "singleAssistantContentPath": "$.answer" }
+            }
+            """,
+            """
+            {
+              "choices": [{
+                "message": {
+                  "role": "assistant",
+                  "content": ["first", {"type":"text","text":"second"}]
+                }
+              }],
+              "tool_calls": [{
+                "function": {"name":"lookup","arguments":{"id":42}}
+              }],
+              "usage": {
+                "prompt_tokens": 7,
+                "completion_tokens": 11,
+                "total_tokens": 18,
+                "cost": 0.125,
+                "latency_ms": 321
+              },
+              "documents": [{
+                "id": "doc-1",
+                "title": "Reference",
+                "content": "Ground truth",
+                "metadata": {"rank":1,"source":"catalog"}
+              }],
+              "answer": "unused fallback"
+            }
+            """);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        var trace = Assert.IsType<Promptly.Domain.ValueObjects.CanonicalTrace>(result.Trace);
+        var message = Assert.Single(trace.Messages);
+        Assert.Equal("assistant", message.Role);
+        Assert.Equal("first\n{\"type\":\"text\",\"text\":\"second\"}", message.Content);
+        var toolCall = Assert.Single(trace.ToolCalls);
+        Assert.Equal("lookup", toolCall.Name);
+        Assert.Equal("{\"id\":42}", toolCall.ArgumentsJson);
+        Assert.NotNull(trace.Usage);
+        Assert.Equal(7, trace.Usage.PromptTokens);
+        Assert.Equal(11, trace.Usage.CompletionTokens);
+        Assert.Equal(18, trace.Usage.TotalTokens);
+        Assert.Equal(0.125m, trace.Usage.Cost);
+        Assert.Equal(321, trace.Usage.LatencyMs);
+        var document = Assert.Single(trace.RetrievedDocs);
+        Assert.Equal("doc-1", document.Id);
+        Assert.Equal("Reference", document.Title);
+        Assert.Equal("Ground truth", document.Content);
+        Assert.NotNull(document.Metadata);
+        Assert.Equal(1, Assert.IsType<JsonElement>(document.Metadata["rank"]).GetInt32());
+        Assert.Equal(
+            "catalog",
+            Assert.IsType<JsonElement>(document.Metadata["source"]).GetString());
+        Assert.Contains("\"choices\"", trace.RawResponse, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ApplyMappingAsync_uses_fallback_when_messages_mapping_is_omitted()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(
+            """{"version":1,"fallback":{"singleAssistantContentPath":"$.answer"}}""",
+            """{"answer":"hello"}""");
+
+        Assert.True(result.Success, result.ErrorMessage);
+        var message = Assert.Single(Assert.IsType<Promptly.Domain.ValueObjects.CanonicalTrace>(
+            result.Trace).Messages);
+        Assert.Equal("assistant", message.Role);
+        Assert.Equal("hello", message.Content);
+    }
+
+    [Fact]
+    public async Task ApplyMappingAsync_uses_fallback_when_messages_items_do_not_match()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(
+            """
+            {
+              "version": 1,
+              "messages": {"itemsPath":"$.missing[*]"},
+              "fallback": {"singleAssistantContentPath":"$.answer"}
+            }
+            """,
+            """{"answer":"fallback value"}""");
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Equal(
+            "fallback value",
+            Assert.Single(result.Trace!.Messages).Content);
+    }
+
+    [Fact]
+    public async Task ApplyMappingAsync_discards_partial_messages_before_fallback()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(
+            """
+            {
+              "version": 1,
+              "messages": {"itemsPath":"$.messages[*]"},
+              "fallback": {"singleAssistantContentPath":"$.answer"}
+            }
+            """,
+            """
+            {
+              "messages": [
+                {"role":"assistant","content":"first"},
+                {"role":"assistant"}
+              ],
+              "answer": "fallback"
+            }
+            """);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Equal("fallback", Assert.Single(result.Trace!.Messages).Content);
+    }
+
+    [Theory]
+    [InlineData(
+        "{\"version\":1,\"messages\":{\"itemsPath\":\"$.missing[*]\"}}",
+        "messages.itemsPath")]
+    [InlineData(
+        "{\"version\":1,\"toolCalls\":{\"itemsPath\":\"$.missing[*]\"}}",
+        "toolCalls.itemsPath")]
+    [InlineData(
+        "{\"version\":1,\"usage\":{\"objectPath\":\"$.missing\",\"totalTokensPath\":\"$.total\"}}",
+        "usage.objectPath")]
+    [InlineData(
+        "{\"version\":1,\"retrievedDocs\":{\"itemsPath\":\"$.documents[*]\",\"contentPath\":\"$.content\"}}",
+        "retrievedDocs.contentPath")]
+    [InlineData(
+        "{\"version\":1,\"fallback\":{\"singleAssistantContentPath\":\"$.missing\"}}",
+        "fallback.singleAssistantContentPath")]
+    public async Task ApplyMappingAsync_reports_configured_required_paths_that_do_not_match(
+        string mappingSpec,
+        string expectedPath)
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(
+            mappingSpec,
+            """{"documents":[{"title":"missing content"}]}""");
+
+        Assert.False(result.Success);
+        Assert.Null(result.Trace);
+        Assert.Equal(expectedPath, result.ErrorPath);
+        Assert.Contains(expectedPath, result.ErrorMessage, StringComparison.Ordinal);
+        Assert.Contains("did not match", result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("{}", "mappingSpec")]
+    [InlineData(" ", "mappingSpec")]
+    [InlineData("null", "mappingSpec")]
+    [InlineData("{\"Version\":1,\"Fallback\":{\"SingleAssistantContentPath\":\"$.answer\"}}", "Version")]
+    [InlineData("{\"version\":\"one\",\"fallback\":{\"singleAssistantContentPath\":\"$.answer\"}}", "version")]
+    [InlineData("{\"version\":1,\"fallback\":{\"singleAssistantContentPath\":5}}", "fallback.singleAssistantContentPath")]
+    [InlineData("{\"version\":1,\"version\":1,\"fallback\":{\"singleAssistantContentPath\":\"$.answer\"}}", "mappingSpec")]
+    [InlineData("{\"version\":1,\"fallback\":{\"singleAssistantContentPath\":\"$.\\ud800\"}}", "mappingSpec")]
+    [InlineData("{\"version\":1,\"fallback\":{\"singleAssistantContentPath\":\"$[\\\"a\\tb\\\"]\"}}", "fallback.singleAssistantContentPath")]
+    [InlineData("{\"version\":1,\"fallback\":{\"singleAssistantContentPath\":\"$['a\\u001fb']\"}}", "fallback.singleAssistantContentPath")]
+    [InlineData("{\"version\":1,\"messages\":{\"itemsPath\":\"$.items[9007199254740992]\"},\"fallback\":{\"singleAssistantContentPath\":\"$.answer\"}}", "messages.itemsPath")]
+    [InlineData("{\"version\":1,\"fallback\":{\"singleAssistantContentPath\":\"$[999999999999999999999999999999999999999]\"}}", "fallback.singleAssistantContentPath")]
+    [InlineData("{\"fallback\":{\"singleAssistantContentPath\":\"$.answer\"}}", "version")]
+    [InlineData("{\"version\":null,\"fallback\":{\"singleAssistantContentPath\":\"$.answer\"}}", "version")]
+    [InlineData("{\"version\":2,\"fallback\":{\"singleAssistantContentPath\":\"$.answer\"}}", "version")]
+    [InlineData("{\"version\":1,\"fallback\":{\"singleAssistantContentPath\":\" \"}}", "fallback.singleAssistantContentPath")]
+    [InlineData("{\"version\":1,\"usage\":{\"objectPath\":\"$.usage\"}}", "usage")]
+    [InlineData("{\"version\":1,\"messages\":{}}", "messages.itemsPath")]
+    [InlineData("{\"version\":1,\"toolCalls\":{}}", "toolCalls.itemsPath")]
+    [InlineData("{\"version\":1,\"usage\":{\"totalTokensPath\":\"$.total\"}}", "usage.objectPath")]
+    [InlineData("{\"version\":1,\"retrievedDocs\":{\"itemsPath\":\"$.docs[*]\"}}", "retrievedDocs.contentPath")]
+    [InlineData("{\"version\":1,\"retrievedDocs\":{\"itemsPath\":\"$.docs[*]\",\"contentPath\":\"$.content\",\"idPath\":\" \"}}", "retrievedDocs.idPath")]
+    public async Task ApplyMappingAsync_rejects_invalid_schema_1_specs(
+        string mappingSpec,
+        string expectedPath)
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(mappingSpec, """{"answer":"hello"}""");
+
+        Assert.False(result.Success);
+        Assert.Null(result.Trace);
+        Assert.Equal(expectedPath, result.ErrorPath);
+        Assert.Contains(expectedPath, result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ApplyMappingAsync_preserves_optional_sections_and_string_arguments()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(
+            """
+            {
+              "version": 1,
+              "toolCalls": {"itemsPath":"$.tools[*]"},
+              "usage": {"objectPath":"$.usage","totalTokensPath":"$.total"},
+              "retrievedDocs": {
+                "itemsPath":"$.docs[*]",
+                "idPath":"$.id",
+                "contentPath":"$.content"
+              }
+            }
+            """,
+            """
+            {
+              "tools": [{"name":"search","arguments":"{\"query\":\"test\"}"}],
+              "usage": {"total":3},
+              "docs": [
+                {"content":"without id"},
+                {"id":2,"content":"numeric id"}
+              ]
+            }
+            """);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Empty(result.Trace!.Messages);
+        var toolCall = Assert.Single(result.Trace.ToolCalls);
+        Assert.Equal("{\"query\":\"test\"}", toolCall.ArgumentsJson);
+        Assert.NotNull(result.Trace.Usage);
+        Assert.Null(result.Trace.Usage.PromptTokens);
+        Assert.Null(result.Trace.Usage.CompletionTokens);
+        Assert.Equal(3, result.Trace.Usage.TotalTokens);
+        Assert.Null(result.Trace.Usage.Cost);
+        Assert.Null(result.Trace.Usage.LatencyMs);
+        Assert.Collection(
+            result.Trace.RetrievedDocs,
+            document => Assert.Null(document.Id),
+            document => Assert.Equal("2", document.Id));
+    }
+
+    [Theory]
+    [InlineData(
+        "{\"version\":1,\"usage\":{\"objectPath\":\"$.usage\",\"totalTokensPath\":\"$.total\"}}",
+        "{\"usage\":{\"total\":\"three\"}}",
+        "usage.totalTokensPath")]
+    [InlineData(
+        "{\"version\":1,\"usage\":{\"objectPath\":\"$.usage\",\"latencyMsPath\":\"$.latency\"}}",
+        "{\"usage\":{\"latency\":1.5}}",
+        "usage.latencyMsPath")]
+    [InlineData(
+        "{\"version\":1,\"usage\":{\"objectPath\":\"$.usage\",\"costPath\":\"$.cost\"}}",
+        "{\"usage\":{\"cost\":\"free\"}}",
+        "usage.costPath")]
+    public async Task ApplyMappingAsync_rejects_configured_usage_values_with_wrong_types(
+        string mappingSpec,
+        string responseJson,
+        string expectedPath)
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(mappingSpec, responseJson);
+
+        Assert.False(result.Success);
+        Assert.Equal(expectedPath, result.ErrorPath);
+        Assert.Contains(expectedPath, result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(
+        "{\"version\":1,\"messages\":{\"itemsPath\":\"$.items[*]\"}}",
+        "{\"items\":[{\"role\":false,\"content\":\"hello\"}]}",
+        "messages.rolePath")]
+    [InlineData(
+        "{\"version\":1,\"toolCalls\":{\"itemsPath\":\"$.items[*]\"}}",
+        "{\"items\":[{\"name\":{\"value\":\"search\"},\"arguments\":{}}]}",
+        "toolCalls.namePath")]
+    [InlineData(
+        "{\"version\":1,\"retrievedDocs\":{\"itemsPath\":\"$.items[*]\",\"contentPath\":\"$.content\"}}",
+        "{\"items\":[{\"content\":42}]}",
+        "retrievedDocs.contentPath")]
+    [InlineData(
+        "{\"version\":1,\"fallback\":{\"singleAssistantContentPath\":\"$.answer\"}}",
+        "{\"answer\":{\"text\":\"hello\"}}",
+        "fallback.singleAssistantContentPath")]
+    public async Task ApplyMappingAsync_rejects_non_string_canonical_fields(
+        string mappingSpec,
+        string responseJson,
+        string expectedPath)
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(mappingSpec, responseJson);
+
+        Assert.False(result.Success);
+        Assert.Equal(expectedPath, result.ErrorPath);
+        Assert.Contains("did not match a string", result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("idPath", "true", "string or number")]
+    [InlineData("idPath", "{}", "string or number")]
+    [InlineData("titlePath", "42", "string")]
+    [InlineData("titlePath", "[]", "string")]
+    public async Task ApplyMappingAsync_rejects_invalid_optional_document_field_types(
+        string pathName,
+        string valueJson,
+        string expectedShape)
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+        var spec = $$"""
+            {
+              "version": 1,
+              "retrievedDocs": {
+                "itemsPath": "$.docs[*]",
+                "contentPath": "$.content",
+                "{{pathName}}": "$.value"
+              }
+            }
+            """;
+
+        var result = await service.ApplyMappingAsync(
+            spec,
+            $$"""{"docs":[{"content":"hello","value":{{valueJson}}}]}""");
+
+        Assert.False(result.Success);
+        Assert.Equal(
+            pathName == "idPath" ? "retrievedDocs.idPath" : "retrievedDocs.titlePath",
+            result.ErrorPath);
+        Assert.Contains(expectedShape, result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ApplyMappingAsync_requires_each_configured_optional_doc_path_to_match()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(
+            """
+            {
+              "version": 1,
+              "retrievedDocs": {
+                "itemsPath":"$.docs[*]",
+                "contentPath":"$.content",
+                "titlePath":"$.title"
+              }
+            }
+            """,
+            """{"docs":[{"content":"first"},{"content":"second"}]}""");
+
+        Assert.False(result.Success);
+        Assert.Equal("retrievedDocs.titlePath", result.ErrorPath);
+    }
+
+    [Theory]
+    [InlineData(
+        "{\"version\":1,\"usage\":{\"objectPath\":\"$.usage[*]\",\"totalTokensPath\":\"$.total\"}}",
+        "{\"usage\":[{\"total\":1},{\"total\":2}]}",
+        "usage.objectPath")]
+    [InlineData(
+        "{\"version\":1,\"usage\":{\"objectPath\":\"$.usage\",\"totalTokensPath\":\"$.values[*]\"}}",
+        "{\"usage\":{\"values\":[1,2]}}",
+        "usage.totalTokensPath")]
+    [InlineData(
+        "{\"version\":1,\"messages\":{\"itemsPath\":\"$.messages[*]\",\"rolePath\":\"$.roles[*]\"}}",
+        "{\"messages\":[{\"roles\":[\"assistant\",\"tool\"],\"content\":\"hello\"}]}",
+        "messages.rolePath")]
+    [InlineData(
+        "{\"version\":1,\"retrievedDocs\":{\"itemsPath\":\"$.docs[*]\",\"contentPath\":\"$.content\",\"titlePath\":\"$.titles[*]\"}}",
+        "{\"docs\":[{\"content\":\"hello\",\"titles\":[\"one\",\"two\"]}]}",
+        "retrievedDocs.titlePath")]
+    public async Task ApplyMappingAsync_rejects_multiple_matches_for_singular_paths(
+        string mappingSpec,
+        string responseJson,
+        string expectedPath)
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(mappingSpec, responseJson);
+
+        Assert.False(result.Success);
+        Assert.Equal(expectedPath, result.ErrorPath);
+        Assert.Contains("more than one value", result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ApplyMappingAsync_rejects_non_object_retrieved_doc_metadata()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(
+            """
+            {
+              "version": 1,
+              "retrievedDocs": {
+                "itemsPath":"$.docs[*]",
+                "contentPath":"$.content",
+                "metadataPath":"$.metadata"
+              }
+            }
+            """,
+            """{"docs":[{"content":"first","metadata":"not an object"}]}""");
+
+        Assert.False(result.Success);
+        Assert.Equal("retrievedDocs.metadataPath", result.ErrorPath);
+        Assert.Contains("did not match an object", result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ApplyMappingAsync_requires_usage_object_path_to_select_an_object()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(
+            """{"version":1,"usage":{"objectPath":"$.total","totalTokensPath":"$"}}""",
+            """{"total":7}""");
+
+        Assert.False(result.Success);
+        Assert.Equal("usage.objectPath", result.ErrorPath);
+        Assert.Contains("did not match an object", result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(
+        "{\"version\":1,\"messages\":{\"itemsPath\":\"$.items[*]\",\"rolePath\":\"$\",\"contentPath\":\"$\"}}",
+        "messages.itemsPath")]
+    [InlineData(
+        "{\"version\":1,\"toolCalls\":{\"itemsPath\":\"$.items[*]\",\"namePath\":\"$\",\"argumentsPath\":\"$\"}}",
+        "toolCalls.itemsPath")]
+    [InlineData(
+        "{\"version\":1,\"retrievedDocs\":{\"itemsPath\":\"$.items[*]\",\"contentPath\":\"$\"}}",
+        "retrievedDocs.itemsPath")]
+    public async Task ApplyMappingAsync_requires_collection_paths_to_select_objects(
+        string mappingSpec,
+        string expectedPath)
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(
+            mappingSpec,
+            """{"items":["scalar"]}""");
+
+        Assert.False(result.Success);
+        Assert.Equal(expectedPath, result.ErrorPath);
+        Assert.Contains("only objects", result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ApplyMappingAsync_reports_the_fallback_path_when_messages_and_fallback_fail()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(
+            """
+            {
+              "version": 1,
+              "messages": {"itemsPath":"$.messages[*]"},
+              "fallback": {"singleAssistantContentPath":"$.answer"}
+            }
+            """,
+            "{}");
+
+        Assert.False(result.Success);
+        Assert.Equal("fallback.singleAssistantContentPath", result.ErrorPath);
+    }
+
+    [Fact]
+    public async Task ApplyMappingAsync_rejects_unknown_schema_fields()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(
+            """
+            {
+              "version": 1,
+              "fallback": {"singleAssistantContentPath":"$.answer"},
+              "unexpected": true
+            }
+            """,
+            """{"answer":"hello"}""");
+
+        Assert.False(result.Success);
+        Assert.Null(result.Trace);
+        Assert.Equal("unexpected", result.ErrorPath);
+        Assert.Contains("unexpected", result.ErrorMessage, StringComparison.Ordinal);
+        Assert.Contains("schema 1", result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ValidateMappingAsync_uses_the_same_schema_and_extraction_rules()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var valid = await service.ValidateMappingAsync(
+            """{"version":1,"fallback":{"singleAssistantContentPath":"$.answer"}}""",
+            """{"answer":"preview"}""");
+        var invalid = await service.ValidateMappingAsync(
+            """{"version":1,"fallback":{"singleAssistantContentPath":"$.missing"}}""",
+            """{"answer":"preview"}""");
+
+        Assert.True(valid.Success, valid.ErrorMessage);
+        Assert.Equal("preview", Assert.Single(valid.Trace!.Messages).Content);
+        Assert.False(invalid.Success);
+        Assert.Equal("fallback.singleAssistantContentPath", invalid.ErrorPath);
+        Assert.Contains(
+            "fallback.singleAssistantContentPath",
+            invalid.ErrorMessage,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ApplyMappingAsync_accepts_canonical_bracket_quoted_members()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(
+            """{"version":1,"fallback":{"singleAssistantContentPath":"$['answer-key']"}}""",
+            """{"answer-key":"bracket member"}""");
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Equal("bracket member", Assert.Single(result.Trace!.Messages).Content);
+    }
+
+    [Fact]
+    public async Task ApplyMappingAsync_does_not_treat_bracket_text_in_a_quoted_member_as_an_index()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(
+            """{"version":1,"fallback":{"singleAssistantContentPath":"$[\"[9007199254740992]\"]"}}""",
+            """{"[9007199254740992]":"quoted member"}""");
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Equal("quoted member", Assert.Single(result.Trace!.Messages).Content);
+    }
+
+    [Fact]
+    public async Task ApplyMappingAsync_accepts_the_maximum_compatible_array_index()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(
+            """{"version":1,"messages":{"itemsPath":"$.items[9007199254740991]"},"fallback":{"singleAssistantContentPath":"$.answer"}}""",
+            """{"items":[],"answer":"fallback"}""");
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Equal("fallback", Assert.Single(result.Trace!.Messages).Content);
+    }
+
+    [Fact]
+    public async Task ApplyMappingAsync_applies_wildcards_to_object_property_values()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(
+            """{"version":1,"messages":{"itemsPath":"$.messages[*]"}}""",
+            """
+            {
+              "messages": {
+                "first": {"role":"assistant","content":"one"},
+                "second": {"role":"tool","content":"two"}
+              }
+            }
+            """);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Collection(
+            result.Trace!.Messages,
+            message => Assert.Equal(("assistant", "one"), (message.Role, message.Content)),
+            message => Assert.Equal(("tool", "two"), (message.Role, message.Content)));
+    }
+
+    [Theory]
+    [InlineData("$.answer[*]", "{\"answer\":\"hello\"}")]
+    [InlineData("$.answer[0]", "{\"answer\":\"hello\"}")]
+    [InlineData("$.answer", "{\"answer\":null}")]
+    public async Task ApplyMappingAsync_does_not_treat_scalar_indexes_wildcards_or_null_as_matches(
+        string path,
+        string responseJson)
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+        var spec = JsonSerializer.Serialize(new
+        {
+            version = 1,
+            fallback = new { singleAssistantContentPath = path }
+        });
+
+        var result = await service.ApplyMappingAsync(spec, responseJson);
+
+        Assert.False(result.Success);
+        Assert.Equal("fallback.singleAssistantContentPath", result.ErrorPath);
+        Assert.Contains("did not match", result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ApplyMappingAsync_caps_the_retained_raw_response()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+        var response = JsonSerializer.Serialize(new { answer = new string('x', 205 * 1024) });
+
+        var result = await service.ApplyMappingAsync(
+            """{"version":1,"fallback":{"singleAssistantContentPath":"$.answer"}}""",
+            response);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.NotNull(result.Trace);
+        Assert.Equal(200 * 1024, Encoding.UTF8.GetByteCount(result.Trace.RawResponse!));
+        Assert.EndsWith("\n... (truncated)", result.Trace.RawResponse, StringComparison.Ordinal);
+        Assert.Equal(205 * 1024, Assert.Single(result.Trace.Messages).Content.Length);
+    }
+
+    [Fact]
+    public async Task ApplyMappingAsync_caps_multibyte_raw_response_on_a_rune_boundary()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+        var content = string.Concat(Enumerable.Repeat("😀", 60 * 1024));
+        var response = $$"""{"answer":"{{content}}"}""";
+
+        var result = await service.ApplyMappingAsync(
+            """{"version":1,"fallback":{"singleAssistantContentPath":"$.answer"}}""",
+            response);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        var trace = Assert.IsType<Promptly.Domain.ValueObjects.CanonicalTrace>(result.Trace);
+        var rawResponse = Assert.IsType<string>(trace.RawResponse);
+        Assert.True(Encoding.UTF8.GetByteCount(rawResponse) <= 200 * 1024);
+        Assert.EndsWith("\n... (truncated)", rawResponse, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            rawResponse.EnumerateRunes(),
+            rune => rune == Rune.ReplacementChar);
+        Assert.NotEmpty(JsonSerializer.Serialize(trace));
+        Assert.Equal(content, Assert.Single(trace.Messages).Content);
+    }
+
+    [Fact]
+    public async Task ApplyMappingAsync_does_not_expose_unexpected_exception_details()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = new MappingService(
+            new ThrowingJsonPathService(),
+            NullLogger<MappingService>.Instance,
+            dbContext);
+
+        var result = await service.ApplyMappingAsync(
+            """{"version":1,"fallback":{"singleAssistantContentPath":"$.answer"}}""",
+            """{"answer":"hello"}""");
+
+        Assert.False(result.Success);
+        Assert.Null(result.Trace);
+        Assert.Equal("fallback.singleAssistantContentPath", result.ErrorPath);
+        Assert.Contains("could not be evaluated", result.ErrorMessage, StringComparison.Ordinal);
+        Assert.DoesNotContain("secret", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("{\"answer\":")]
+    [InlineData("{\"answer\":\"first\",\"answer\":\"second\"}")]
+    [InlineData("{\"answer\":\"ok\",\"other\":1,\"other\":2}")]
+    [InlineData("{\"answer\":\"\\ud800\"}")]
+    public async Task ApplyMappingAsync_rejects_noncanonical_response_json(string responseJson)
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.ApplyMappingAsync(
+            """{"version":1,"fallback":{"singleAssistantContentPath":"$.answer"}}""",
+            responseJson);
+
+        Assert.False(result.Success);
+        Assert.Null(result.Trace);
+        Assert.Equal("responseJson", result.ErrorPath);
+        Assert.DoesNotContain("first", result.ErrorMessage, StringComparison.Ordinal);
+        Assert.DoesNotContain("second", result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    private static PromptlyDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<PromptlyDbContext>()
+            .UseInMemoryDatabase($"promptly-mapping-{Guid.NewGuid():N}")
+            .Options;
+        return new PromptlyDbContext(options);
+    }
+
+    private static MappingService CreateService(PromptlyDbContext dbContext) =>
+        new(
+            new JsonPathService(NullLogger<JsonPathService>.Instance),
+            NullLogger<MappingService>.Instance,
+            dbContext);
+
+    private sealed class ThrowingJsonPathService : IJsonPathService
+    {
+        public JsonElement? SelectToken(string jsonString, string jsonPath) =>
+            jsonString == "{}"
+                ? null
+                : throw new UnexpectedMappingException("secret implementation detail");
+
+        public IEnumerable<JsonElement> SelectTokens(string jsonString, string jsonPath) =>
+            throw new UnexpectedMappingException("secret implementation detail");
+    }
+
+    private sealed class UnexpectedMappingException(string message) : Exception(message);
+}

--- a/tests/Promptly.Application.UnitTests/MappingServiceTests.cs
+++ b/tests/Promptly.Application.UnitTests/MappingServiceTests.cs
@@ -700,7 +700,7 @@ public sealed class MappingServiceTests
     }
 
     [Fact]
-    public async Task ApplyMappingAsync_does_not_expose_unexpected_exception_details()
+    public async Task ApplyMappingAsync_does_not_expose_unexpected_adapter_exception_details()
     {
         await using var dbContext = CreateDbContext();
         var service = new MappingService(
@@ -714,8 +714,8 @@ public sealed class MappingServiceTests
 
         Assert.False(result.Success);
         Assert.Null(result.Trace);
-        Assert.Equal("fallback.singleAssistantContentPath", result.ErrorPath);
-        Assert.Contains("could not be evaluated", result.ErrorMessage, StringComparison.Ordinal);
+        Assert.Null(result.ErrorPath);
+        Assert.Equal("Mapping failed due to an unexpected error", result.ErrorMessage);
         Assert.DoesNotContain("secret", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
     }
 

--- a/tests/Promptly.Application.UnitTests/MappingSpecPersistenceTests.cs
+++ b/tests/Promptly.Application.UnitTests/MappingSpecPersistenceTests.cs
@@ -1,0 +1,209 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Promptly.Application.Data;
+using Promptly.Application.Services;
+using Promptly.Infrastructure.Services;
+
+namespace Promptly.Application.UnitTests;
+
+public sealed class MappingSpecPersistenceTests
+{
+    private const string ValidSpec =
+        """{"version":1,"fallback":{"singleAssistantContentPath":"$.answer"}}""";
+
+    [Fact]
+    public async Task Save_and_get_preserve_the_public_mapping_spec_contract()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+        var endpointId = Guid.NewGuid();
+        var before = DateTime.UtcNow;
+
+        var saved = await service.SaveMappingSpecAsync(
+            endpointId,
+            "default",
+            ValidSpec);
+        var loaded = await service.GetMappingSpecByIdAsync(saved.Id);
+
+        Assert.NotEqual(Guid.Empty, saved.Id);
+        Assert.Equal(endpointId, saved.EndpointId);
+        Assert.Equal("default", saved.Name);
+        Assert.False(saved.IsDefault);
+        Assert.InRange(saved.CreatedAt, before, DateTime.UtcNow);
+        Assert.InRange(saved.UpdatedAt, before, DateTime.UtcNow);
+        Assert.Same(saved, loaded);
+    }
+
+    [Fact]
+    public async Task GetMappingSpecsByEndpointAsync_orders_the_default_first_then_newest()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+        var endpointId = Guid.NewGuid();
+        var oldest = await service.SaveMappingSpecAsync(endpointId, "oldest", ValidSpec);
+        var newest = await service.SaveMappingSpecAsync(endpointId, "newest", ValidSpec);
+        var defaultSpec = await service.SaveMappingSpecAsync(endpointId, "default", ValidSpec);
+        await service.SaveMappingSpecAsync(Guid.NewGuid(), "other endpoint", ValidSpec);
+        oldest.CreatedAt = DateTime.UtcNow.AddMinutes(-2);
+        defaultSpec.CreatedAt = DateTime.UtcNow.AddMinutes(-1);
+        newest.CreatedAt = DateTime.UtcNow;
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        await service.SetDefaultMappingAsync(defaultSpec.Id);
+
+        var specs = await service.GetMappingSpecsByEndpointAsync(endpointId);
+
+        Assert.Collection(
+            specs,
+            spec => Assert.Equal("default", spec.Name),
+            spec => Assert.Equal("newest", spec.Name),
+            spec => Assert.Equal("oldest", spec.Name));
+    }
+
+    [Fact]
+    public async Task SetDefaultMappingAsync_clears_only_defaults_for_the_same_endpoint()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+        var endpointId = Guid.NewGuid();
+        var first = await service.SaveMappingSpecAsync(endpointId, "first", ValidSpec);
+        var replacement = await service.SaveMappingSpecAsync(endpointId, "replacement", ValidSpec);
+        var otherEndpoint = await service.SaveMappingSpecAsync(
+            Guid.NewGuid(),
+            "other",
+            ValidSpec);
+        await service.SetDefaultMappingAsync(first.Id);
+        await service.SetDefaultMappingAsync(otherEndpoint.Id);
+
+        await service.SetDefaultMappingAsync(replacement.Id);
+
+        Assert.False(first.IsDefault);
+        Assert.True(replacement.IsDefault);
+        Assert.True(otherEndpoint.IsDefault);
+        Assert.Same(replacement, await service.GetDefaultMappingAsync(endpointId));
+    }
+
+    [Fact]
+    public async Task UpdateMappingSpecAsync_updates_content_and_timestamp()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+        var saved = await service.SaveMappingSpecAsync(Guid.NewGuid(), "before", ValidSpec);
+        saved.UpdatedAt = DateTime.UtcNow.AddDays(-1);
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var priorUpdatedAt = saved.UpdatedAt;
+
+        var updated = await service.UpdateMappingSpecAsync(
+            saved.Id,
+            "after",
+            """{"version":1,"fallback":{"singleAssistantContentPath":"$.result"}}""");
+
+        Assert.Same(saved, updated);
+        Assert.Equal("after", updated.Name);
+        Assert.Equal(
+            """{"version":1,"fallback":{"singleAssistantContentPath":"$.result"}}""",
+            updated.SpecJson);
+        Assert.True(updated.UpdatedAt > priorUpdatedAt);
+    }
+
+    [Fact]
+    public async Task DeleteMappingSpecAsync_removes_the_spec()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+        var saved = await service.SaveMappingSpecAsync(Guid.NewGuid(), "delete", ValidSpec);
+
+        await service.DeleteMappingSpecAsync(saved.Id);
+
+        Assert.Null(await service.GetMappingSpecByIdAsync(saved.Id));
+    }
+
+    [Theory]
+    [InlineData("update")]
+    [InlineData("set-default")]
+    [InlineData("delete")]
+    public async Task Mutation_methods_reject_unknown_mapping_specs(string operation)
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+        var missingId = Guid.NewGuid();
+
+        var exception = operation switch
+        {
+            "update" => await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                service.UpdateMappingSpecAsync(missingId, "name", ValidSpec)),
+            "set-default" => await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                service.SetDefaultMappingAsync(missingId)),
+            "delete" => await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                service.DeleteMappingSpecAsync(missingId)),
+            _ => throw new InvalidOperationException($"Unknown test operation {operation}")
+        };
+
+        Assert.Contains(missingId.ToString(), exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("{\"fallback\":{\"singleAssistantContentPath\":\"$.answer\"}}", "version")]
+    [InlineData("{\"version\":\"one\",\"fallback\":{\"singleAssistantContentPath\":\"$.answer\"}}", "version")]
+    [InlineData("{\"version\":1,\"fallback\":{\"singleAssistantContentPath\":5}}", "fallback.singleAssistantContentPath")]
+    [InlineData("{\"version\":1,\"version\":1,\"fallback\":{\"singleAssistantContentPath\":\"$.answer\"}}", "mappingSpec")]
+    [InlineData("{\"version\":1,\"fallback\":{\"singleAssistantContentPath\":\"$.\\ud800\"}}", "mappingSpec")]
+    [InlineData("{\"version\":1,\"fallback\":{\"singleAssistantContentPath\":\"$[\\\"a\\tb\\\"]\"}}", "fallback.singleAssistantContentPath")]
+    [InlineData("{\"version\":1,\"fallback\":{\"singleAssistantContentPath\":\"$['a\\u001fb']\"}}", "fallback.singleAssistantContentPath")]
+    [InlineData("{\"version\":1,\"messages\":{\"itemsPath\":\"$.items[9007199254740992]\"},\"fallback\":{\"singleAssistantContentPath\":\"$.answer\"}}", "messages.itemsPath")]
+    [InlineData("{\"version\":1,\"fallback\":{\"singleAssistantContentPath\":\"$[999999999999999999999999999999999999999]\"}}", "fallback.singleAssistantContentPath")]
+    [InlineData("{\"version\":null,\"fallback\":{\"singleAssistantContentPath\":\"$.answer\"}}", "version")]
+    [InlineData("{\"version\":2,\"fallback\":{\"singleAssistantContentPath\":\"$.answer\"}}", "version")]
+    [InlineData("{\"version\":1,\"fallback\":{\"singleAssistantContentPath\":\"$[\"}}", "fallback.singleAssistantContentPath")]
+    [InlineData("{\"version\":1,\"fallback\":{\"singleAssistantContentPath\":\"$..answer\"}}", "fallback.singleAssistantContentPath")]
+    [InlineData("{\"version\":1,\"fallback\":{\"singleAssistantContentPath\":\"$[-1]\"}}", "fallback.singleAssistantContentPath")]
+    [InlineData("{\"version\":1,\"fallback\":{\"singleAssistantContentPath\":\"$[0:2]\"}}", "fallback.singleAssistantContentPath")]
+    [InlineData("{\"version\":1,\"fallback\":{\"singleAssistantContentPath\":\"$[?(@.enabled)]\"}}", "fallback.singleAssistantContentPath")]
+    public async Task SaveMappingSpecAsync_rejects_invalid_specs_without_persisting(
+        string invalidSpec,
+        string expectedPath)
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+
+        var exception = await Assert.ThrowsAsync<MappingSpecValidationException>(() =>
+            service.SaveMappingSpecAsync(Guid.NewGuid(), "invalid", invalidSpec));
+
+        Assert.Equal(expectedPath, exception.Path);
+        Assert.Empty(dbContext.MappingSpecs);
+    }
+
+    [Fact]
+    public async Task UpdateMappingSpecAsync_rejects_invalid_specs_without_mutating_the_spec()
+    {
+        await using var dbContext = CreateDbContext();
+        var service = CreateService(dbContext);
+        var saved = await service.SaveMappingSpecAsync(Guid.NewGuid(), "original", ValidSpec);
+
+        var exception = await Assert.ThrowsAsync<MappingSpecValidationException>(() =>
+            service.UpdateMappingSpecAsync(
+                saved.Id,
+                "invalid update",
+                """{"version":1,"messages":{"itemsPath":" "}}"""));
+
+        Assert.Equal("messages.itemsPath", exception.Path);
+        Assert.Equal("original", saved.Name);
+        Assert.Equal(ValidSpec, saved.SpecJson);
+        Assert.Equal(
+            1,
+            await dbContext.MappingSpecs.CountAsync(TestContext.Current.CancellationToken));
+    }
+
+    private static PromptlyDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<PromptlyDbContext>()
+            .UseInMemoryDatabase($"promptly-mapping-persistence-{Guid.NewGuid():N}")
+            .Options;
+        return new PromptlyDbContext(options);
+    }
+
+    private static MappingService CreateService(PromptlyDbContext dbContext) =>
+        new(
+            new JsonPathService(NullLogger<JsonPathService>.Instance),
+            NullLogger<MappingService>.Instance,
+            dbContext);
+}

--- a/tests/Promptly.Application.UnitTests/Promptly.Application.UnitTests.csproj
+++ b/tests/Promptly.Application.UnitTests/Promptly.Application.UnitTests.csproj
@@ -12,7 +12,7 @@
     <CoverletOutput>$(MSBuildProjectDirectory)/../../artifacts/test-results/csharp/coverage/coverage</CoverletOutput>
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <DeterministicReport>true</DeterministicReport>
-    <Include>[Promptly.Application]Promptly.Application.Services.ExpectationEvaluator,[Promptly.Application]Promptly.Application.Services.BoundedRegexMatcher</Include>
+    <Include>[Promptly.Application]Promptly.Application.Services.ExpectationEvaluator,[Promptly.Application]Promptly.Application.Services.BoundedRegexMatcher,[Promptly.Application]Promptly.Application.Services.MappingService*,[Promptly.Application]Promptly.Application.Services.MappingSpecValidationException</Include>
     <Threshold>90</Threshold>
     <ThresholdType>line,branch</ThresholdType>
     <ThresholdStat>total</ThresholdStat>

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,12 +2,12 @@
 
 Promptly's automated test foundation is being added in dependency-ordered slices under issue #18.
 
-The first C# slice exercises the public behavior of `ExpectationEvaluator` and `BoundedRegexMatcher`. It fails zero-test runs and enforces at least 90% line and branch coverage for that initial production cohort:
+The expanding C# gate exercises the public behavior of `ExpectationEvaluator`, `BoundedRegexMatcher`, and `MappingService`, including schema-1 extraction and mapping-spec persistence validation. It fails zero-test runs and enforces at least 90% line and branch coverage for both the measured production cohort and each named production class:
 
 ```bash
 dotnet test tests/Promptly.Application.UnitTests/Promptly.Application.UnitTests.csproj --configuration Release --settings tests/Promptly.runsettings --logger "trx;LogFileName=Promptly.Application.UnitTests.trx" --results-directory artifacts/test-results/csharp
 ```
 
-The ignored `artifacts/test-results/csharp` directory receives the TRX result plus Cobertura and JSON coverage reports. GitHub Actions runs the same gate for every pull request and `main` push and retains those artifacts for 14 days.
+The ignored `artifacts/test-results/csharp` directory receives the TRX result plus Cobertura and JSON coverage reports. GitHub Actions runs the same gate for every pull request and `main` push, verifies the exact measured assembly and source cohort, and retains those artifacts for 14 days.
 
 This scoped gate is not evidence of repository-wide 90% coverage; issues #18 and #19 remain open until every unit-testable production area and language stack is included in the required aggregate gates.


### PR DESCRIPTION
## Summary

- enforce one strict canonical schema-1 MappingSpec contract across worker proposals, application validation, persistence, controllers, and web error handling
- align Python extraction with JsonPath.Net for the admitted member, index, and wildcard subset, including exact cardinality, fallback, type, numeric, depth, duplicate-key, Unicode, and raw-response boundaries
- reject invalid specs before persistence and return structured validation paths without leaking internal exceptions
- remove the obsolete jsonpath-ng runtime dependency after replacing it with a deterministic compatibility evaluator
- add complete public-behavior mapping, persistence, and controller tests plus an exact per-class Application coverage cohort
- resolve all six CodeQL code-quality findings with narrow exception catches, resource-preserving projections, and equivalent short-circuit traversal

## Stack

1. #48 — application regex/test foundation
2. #50 — frontend quality gate
3. #51 — worker runtime and cross-language verification
4. #52 — dependency remediation and continuous security scanning
5. this PR — strict cross-runtime mapping contracts

Base exact head: `61b81a4efb3310eab32832fa2032f165d7de167f`
This PR exact head: `b09f9732963c4b733991b872cd022c3d1bb1d2d6`

## Verification

- locked .NET restore, Release warning-as-error build, and dotnet format: passed
- application tests: 201 passed, 2 explicit opt-in live-contract skips, 0 failed
- measured Application cohort: 96.40% line / 94.28% branch
- MappingService: 96.32% line / 95.00% branch; every required top-level class is above 90% line and branch
- exact assembly, source, class, dependency-scan, and artifact reconciliation: passed
- worker tests: 167 passed; 98.78% line / 98.82% branch
- worker Ruff, strict mypy, Bandit, runtime/full pip-audit, locked uv graph, Compose validation, non-root image inspection, and OpenAI/AzureOpenAI container smoke: passed
- web tests: 128 passed; 97.49% line / 92.13% branch
- web typecheck, zero-warning lint, full/production npm audits, and release build: passed; the existing chunk advisory remains tracked by #49
- exact-head Application, Web, Worker, C#/JavaScript/Python CodeQL, and CodeQL summary checks: passed
- actionlint and git diff checks: passed
- all six CodeQL review threads addressed; exact-head automated Codex re-review reports no major issues
- independent final cross-runtime and review-follow-up audits: no remaining actionable findings

## Tracking

Progresses #1, #18, #19, #37, and #47.

The broader coverage, quality-gate, contract, and production-readiness issues intentionally remain open for the later stack slices and default-branch completion. No coverage thresholds were lowered and no findings were waived.