### PR TITLE
Enforce complete Infrastructure coverage cohort

### DIFF
--- a/.github/workflows/application-verification.yml
+++ b/.github/workflows/application-verification.yml
@@ -38,7 +38,10 @@ jobs:
         run: dotnet restore Promptly.slnx --locked-mode
 
       - name: Build
-        run: dotnet build Promptly.slnx --configuration Release --no-restore
+        run: dotnet build Promptly.slnx --configuration Release --no-restore --warnaserror
+
+      - name: Verify C# formatting
+        run: dotnet format Promptly.slnx --verify-no-changes --no-restore
 
       - name: Clean application test artifacts
         shell: pwsh
@@ -116,12 +119,12 @@ jobs:
         run: |
           [xml]$coverage = Get-Content artifacts/test-results/csharp/coverage/coverage.cobertura.xml -Raw
           $packages = @($coverage.coverage.packages.package)
+          $expectedAssemblies = @("Promptly.Application", "Promptly.Infrastructure") | Sort-Object
           $actualAssemblies = @(
             $packages |
               Where-Object { @($_.classes.class).Count -gt 0 } |
               ForEach-Object { [string]$_.name }
           ) | Sort-Object
-          $expectedAssemblies = @("Promptly.Application")
           $assemblyDifference = Compare-Object $expectedAssemblies $actualAssemblies
           if ($assemblyDifference) {
             throw "Unexpected measured C# assembly cohort: $($assemblyDifference | Out-String)"
@@ -137,6 +140,30 @@ jobs:
             return [IO.Path]::GetRelativePath((Get-Location).Path, $fullPath).Replace('\', '/')
           }
 
+          $expectedInfrastructureSources = @(
+            Get-ChildItem Promptly.Infrastructure -Filter *.cs -Recurse |
+              Where-Object { $_.FullName -notmatch '[/\\](bin|obj)[/\\]' } |
+              ForEach-Object { Get-RepositoryRelativePath $_.FullName }
+          ) | Sort-Object -Unique
+          $infrastructurePackage = $packages |
+            Where-Object { $_.name -eq "Promptly.Infrastructure" } |
+            Select-Object -First 1
+          $actualInfrastructureSources = @(
+            $infrastructurePackage.classes.class |
+              ForEach-Object { Get-RepositoryRelativePath ([string]$_.filename) }
+          ) | Sort-Object -Unique
+          $infrastructureDifference = Compare-Object `
+            $expectedInfrastructureSources `
+            $actualInfrastructureSources
+          if ($infrastructureDifference) {
+            throw "Incomplete Infrastructure coverage source cohort: $($infrastructureDifference | Out-String)"
+          }
+
+          $expectedApplicationSources = @(
+            "Promptly.Application/Services/BoundedRegexMatcher.cs"
+            "Promptly.Application/Services/ExpectationEvaluator.cs"
+            "Promptly.Application/Services/MappingService.cs"
+          ) | Sort-Object
           $applicationPackage = $packages |
             Where-Object { $_.name -eq "Promptly.Application" } |
             Select-Object -First 1
@@ -144,11 +171,6 @@ jobs:
             $applicationPackage.classes.class |
               ForEach-Object { Get-RepositoryRelativePath ([string]$_.filename) }
           ) | Sort-Object -Unique
-          $expectedApplicationSources = @(
-            "Promptly.Application/Services/BoundedRegexMatcher.cs"
-            "Promptly.Application/Services/ExpectationEvaluator.cs"
-            "Promptly.Application/Services/MappingService.cs"
-          ) | Sort-Object
           $applicationDifference = Compare-Object `
             $expectedApplicationSources `
             $actualApplicationSources
@@ -156,16 +178,18 @@ jobs:
             throw "Unexpected scoped Application coverage cohort: $($applicationDifference | Out-String)"
           }
 
-          $lineRate = [double]::Parse(
-            [string]$applicationPackage.'line-rate',
-            [Globalization.CultureInfo]::InvariantCulture)
-          $branchRate = [double]::Parse(
-            [string]$applicationPackage.'branch-rate',
-            [Globalization.CultureInfo]::InvariantCulture)
-          if ($lineRate -lt 0.90 -or $branchRate -lt 0.90) {
-            throw "Application cohort coverage is below 90%: line=$lineRate branch=$branchRate"
+          foreach ($package in @($applicationPackage, $infrastructurePackage)) {
+            $lineRate = [double]::Parse(
+              [string]$package.'line-rate',
+              [Globalization.CultureInfo]::InvariantCulture)
+            $branchRate = [double]::Parse(
+              [string]$package.'branch-rate',
+              [Globalization.CultureInfo]::InvariantCulture)
+            if ($lineRate -lt 0.90 -or $branchRate -lt 0.90) {
+              throw "Coverage for $($package.name) is below 90%: line=$lineRate branch=$branchRate"
+            }
+            Write-Host "$($package.name): line=$('{0:P2}' -f $lineRate) branch=$('{0:P2}' -f $branchRate)"
           }
-          Write-Host "Promptly.Application: line=$('{0:P2}' -f $lineRate) branch=$('{0:P2}' -f $branchRate)"
 
           $requiredClasses = @(
             "Promptly.Application.Services.BoundedRegexMatcher"

--- a/tests/Promptly.Application.UnitTests/ApiKeyAuthenticationHandlerTests.cs
+++ b/tests/Promptly.Application.UnitTests/ApiKeyAuthenticationHandlerTests.cs
@@ -1,0 +1,149 @@
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Promptly.Application.Data;
+using Promptly.Domain.Entities;
+using Promptly.Infrastructure.Security;
+
+namespace Promptly.Application.UnitTests;
+
+public sealed class ApiKeyAuthenticationHandlerTests
+{
+    [Fact]
+    public async Task Missing_header_returns_no_authentication_result()
+    {
+        var observation = await AuthenticateAsync(null);
+
+        Assert.True(observation.Result.None);
+        Assert.False(observation.Result.Succeeded);
+        Assert.Null(observation.LastUsedAt);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Blank_header_is_rejected(string headerValue)
+    {
+        var observation = await AuthenticateAsync(headerValue);
+
+        Assert.False(observation.Result.Succeeded);
+        Assert.Equal("Invalid API Key", observation.Result.Failure?.Message);
+        Assert.Null(observation.LastUsedAt);
+    }
+
+    [Fact]
+    public async Task Unknown_key_is_rejected()
+    {
+        var observation = await AuthenticateAsync("unknown-key");
+
+        Assert.False(observation.Result.Succeeded);
+        Assert.Equal("Invalid API Key", observation.Result.Failure?.Message);
+        Assert.Null(observation.LastUsedAt);
+    }
+
+    [Fact]
+    public async Task Expired_key_is_rejected_without_updating_last_use()
+    {
+        var observation = await AuthenticateAsync(
+            ValidApiKey,
+            DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(1)));
+
+        Assert.False(observation.Result.Succeeded);
+        Assert.Equal("API Key has expired", observation.Result.Failure?.Message);
+        Assert.Null(observation.LastUsedAt);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Valid_key_authenticates_project_claims_and_records_use(bool hasFutureExpiry)
+    {
+        var before = DateTime.UtcNow;
+        var observation = await AuthenticateAsync(
+            ValidApiKey,
+            hasFutureExpiry ? DateTime.UtcNow.AddHours(1) : null);
+
+        Assert.True(observation.Result.Succeeded);
+        Assert.Equal(OwnerUserId, observation.Result.Principal?.FindFirstValue(ClaimTypes.NameIdentifier));
+        Assert.Equal(ProjectId.ToString(), observation.Result.Principal?.FindFirstValue("ProjectId"));
+        Assert.Equal(ApiKeyId.ToString(), observation.Result.Principal?.FindFirstValue("ApiKeyId"));
+        Assert.InRange(Assert.IsType<DateTime>(observation.LastUsedAt), before, DateTime.UtcNow);
+    }
+
+    private const string ValidApiKey = "promptly-test-api-key";
+    private const string OwnerUserId = "owner-123";
+    private static readonly Guid ProjectId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid ApiKeyId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private static async Task<AuthenticationObservation> AuthenticateAsync(
+        string? providedApiKey,
+        DateTime? expiresAt = null)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(UrlEncoder.Default);
+        services.AddDbContext<PromptlyDbContext>(options =>
+            options.UseInMemoryDatabase($"api-key-tests-{Guid.NewGuid():N}"));
+        services
+            .AddAuthentication("ApiKey")
+            .AddScheme<AuthenticationSchemeOptions, ApiKeyAuthenticationHandler>(
+                "ApiKey",
+                _ => { });
+
+        await using var provider = services.BuildServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<PromptlyDbContext>();
+        dbContext.Users.Add(new User
+        {
+            Id = OwnerUserId,
+            UserName = "owner",
+            NormalizedUserName = "OWNER"
+        });
+        dbContext.Projects.Add(new Project
+        {
+            Id = ProjectId,
+            Name = "Project",
+            OwnerUserId = OwnerUserId
+        });
+        dbContext.ProjectApiKeys.Add(new ProjectApiKey
+        {
+            Id = ApiKeyId,
+            ProjectId = ProjectId,
+            Name = "Automation",
+            KeyHashSha256 = HashApiKey(ValidApiKey),
+            KeyLastFourChars = "-key",
+            ExpiresAt = expiresAt
+        });
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = scope.ServiceProvider
+        };
+        if (providedApiKey != null)
+        {
+            httpContext.Request.Headers["X-API-Key"] = providedApiKey;
+        }
+
+        var result = await httpContext.AuthenticateAsync("ApiKey");
+        var lastUsedAt = await dbContext.ProjectApiKeys
+            .AsNoTracking()
+            .Where(key => key.Id == ApiKeyId)
+            .Select(key => key.LastUsedAt)
+            .SingleAsync(TestContext.Current.CancellationToken);
+
+        return new AuthenticationObservation(result, lastUsedAt);
+    }
+
+    private static string HashApiKey(string apiKey) =>
+        Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(apiKey)));
+
+    private sealed record AuthenticationObservation(
+        AuthenticateResult Result,
+        DateTime? LastUsedAt);
+}

--- a/tests/Promptly.Application.UnitTests/InfrastructureServiceTests.cs
+++ b/tests/Promptly.Application.UnitTests/InfrastructureServiceTests.cs
@@ -1,0 +1,220 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using Promptly.Domain.Entities;
+using Promptly.Infrastructure.Configuration;
+using Promptly.Infrastructure.Services;
+
+namespace Promptly.Application.UnitTests;
+
+public sealed class DataProtectionEncryptionServiceTests
+{
+    [Fact]
+    public void Encryption_round_trips_without_exposing_the_plaintext()
+    {
+        var service = CreateService();
+
+        var cipherText = service.Encrypt("sensitive-value");
+
+        Assert.NotEqual("sensitive-value", cipherText);
+        Assert.Equal("sensitive-value", service.Decrypt(cipherText));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Blank_values_are_preserved(string? value)
+    {
+        var service = CreateService();
+
+        Assert.Equal(value, service.Encrypt(value!));
+        Assert.Equal(value, service.Decrypt(value!));
+    }
+
+    [Fact]
+    public void Decryption_wraps_data_protected_by_a_different_provider()
+    {
+        var cipherText = CreateService().Encrypt("sensitive-value");
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            CreateService().Decrypt(cipherText));
+
+        Assert.Contains("encryption key may have changed", exception.Message, StringComparison.Ordinal);
+        Assert.NotNull(exception.InnerException);
+    }
+
+    private static DataProtectionEncryptionService CreateService() =>
+        new(new EphemeralDataProtectionProvider());
+}
+
+public sealed class JwtServiceTests
+{
+    [Fact]
+    public void GenerateToken_emits_a_valid_signed_identity_token()
+    {
+        var now = DateTime.UtcNow;
+        var settings = new JwtSettings
+        {
+            Issuer = "promptly-tests",
+            Audience = "promptly-clients",
+            Key = "unit-test-signing-key-that-is-at-least-32-bytes",
+            ExpiryMinutes = 15
+        };
+        var service = new JwtService(Options.Create(settings));
+        var user = new User
+        {
+            Id = "user-123",
+            Email = "user@example.test",
+            UserName = "test-user"
+        };
+
+        var encodedToken = service.GenerateToken(user);
+
+        var handler = new JwtSecurityTokenHandler();
+        var principal = handler.ValidateToken(
+            encodedToken,
+            new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidIssuer = settings.Issuer,
+                ValidateAudience = true,
+                ValidAudience = settings.Audience,
+                ValidateLifetime = true,
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(settings.Key)),
+                ClockSkew = TimeSpan.Zero
+            },
+            out var validatedToken);
+
+        var jwt = Assert.IsType<JwtSecurityToken>(validatedToken);
+        Assert.Equal(SecurityAlgorithms.HmacSha256, jwt.Header.Alg);
+        Assert.Equal("user-123", principal.FindFirstValue(ClaimTypes.NameIdentifier));
+        Assert.Equal("user@example.test", principal.FindFirstValue(ClaimTypes.Email));
+        Assert.Equal("test-user", principal.FindFirstValue(ClaimTypes.Name));
+        Assert.InRange(jwt.ValidTo, now.AddMinutes(14), now.AddMinutes(16));
+    }
+}
+
+public sealed class YamlServiceTests
+{
+    private readonly YamlService _service = new(NullLogger<YamlService>.Instance);
+
+    [Fact]
+    public void DeserializeTests_maps_snake_case_documents_and_ignores_unknown_fields()
+    {
+        var suiteId = Guid.NewGuid();
+        const string yaml = """
+            - id: case-1
+              name: Greeting
+              description: Greets the caller
+              ignored_field: ignored
+              input:
+                messages:
+                  - role: user
+                    content: Hello
+              expectations:
+                - type: contains_text
+                  text: Hello
+            """;
+
+        var testCase = Assert.Single(_service.DeserializeTests(yaml, suiteId));
+
+        Assert.Equal(suiteId, testCase.SuiteId);
+        Assert.Equal("case-1", testCase.ExternalId);
+        Assert.Equal("Greeting", testCase.Name);
+        Assert.Equal("Greets the caller", testCase.Description);
+        using var input = System.Text.Json.JsonDocument.Parse(testCase.InputSpecJson);
+        Assert.Equal(
+            "Hello",
+            input.RootElement.GetProperty("messages")[0].GetProperty("content").GetString());
+        using var expectations = System.Text.Json.JsonDocument.Parse(testCase.ExpectationsJson);
+        Assert.Equal("contains_text", expectations.RootElement[0].GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public void SerializeTests_round_trips_identity_and_null_collections_as_empty_collections()
+    {
+        var original = new List<TestCase>
+        {
+            new()
+            {
+                ExternalId = "case-1",
+                Name = "Greeting",
+                Description = "Greets the caller",
+                InputSpecJson = "{}",
+                ExpectationsJson = "[]"
+            },
+            new()
+            {
+                ExternalId = "case-2",
+                Name = "Defaults",
+                InputSpecJson = "null",
+                ExpectationsJson = "null"
+            }
+        };
+
+        var yaml = _service.SerializeTests(original);
+        var roundTripped = _service.DeserializeTests(yaml, Guid.NewGuid());
+
+        Assert.Contains("id: case-1", yaml, StringComparison.Ordinal);
+        Assert.Collection(
+            roundTripped,
+            testCase =>
+            {
+                Assert.Equal("Greeting", testCase.Name);
+                Assert.Equal("Greets the caller", testCase.Description);
+                Assert.Equal("{}", testCase.InputSpecJson);
+                Assert.Equal("[]", testCase.ExpectationsJson);
+            },
+            testCase =>
+            {
+                Assert.Equal("{}", testCase.InputSpecJson);
+                Assert.Equal("[]", testCase.ExpectationsJson);
+            });
+    }
+
+    [Fact]
+    public void Empty_documents_round_trip_as_an_empty_test_collection()
+    {
+        var yaml = _service.SerializeTests([]);
+
+        Assert.Empty(_service.DeserializeTests(yaml, Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void DeserializeTests_wraps_invalid_yaml_with_context()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            _service.DeserializeTests("tests: [unterminated", Guid.NewGuid()));
+
+        Assert.StartsWith("Failed to parse YAML:", exception.Message, StringComparison.Ordinal);
+        Assert.NotNull(exception.InnerException);
+    }
+
+    [Theory]
+    [InlineData("not-json", "[]")]
+    [InlineData("{}", "not-json")]
+    public void SerializeTests_wraps_invalid_json_with_context(
+        string inputSpecJson,
+        string expectationsJson)
+    {
+        var testCase = new TestCase
+        {
+            ExternalId = "invalid",
+            Name = "Invalid",
+            InputSpecJson = inputSpecJson,
+            ExpectationsJson = expectationsJson
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            _service.SerializeTests([testCase]));
+
+        Assert.StartsWith("Failed to generate YAML:", exception.Message, StringComparison.Ordinal);
+        Assert.NotNull(exception.InnerException);
+    }
+}

--- a/tests/Promptly.Application.UnitTests/JsonPathServiceTests.cs
+++ b/tests/Promptly.Application.UnitTests/JsonPathServiceTests.cs
@@ -57,4 +57,32 @@ public sealed class JsonPathServiceTests
         Assert.Contains(invalidPath, exception.Message, StringComparison.Ordinal);
         Assert.NotNull(exception.InnerException);
     }
+
+    [Fact]
+    public void Selection_treats_a_json_null_document_as_no_match()
+    {
+        Assert.Null(_service.SelectToken("null", "$"));
+        Assert.Empty(_service.SelectTokens("null", "$"));
+    }
+
+    [Fact]
+    public void Selection_filters_a_matched_json_null_value()
+    {
+        const string json = """{ "value": null }""";
+
+        Assert.Null(_service.SelectToken(json, "$.value"));
+        Assert.Empty(_service.SelectTokens(json, "$.value"));
+    }
+
+    [Fact]
+    public void SelectTokens_wraps_an_invalid_path_with_context()
+    {
+        const string invalidPath = "$[";
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            _service.SelectTokens("{}", invalidPath).ToArray());
+
+        Assert.Contains(invalidPath, exception.Message, StringComparison.Ordinal);
+        Assert.NotNull(exception.InnerException);
+    }
 }

--- a/tests/Promptly.Application.UnitTests/Promptly.Application.UnitTests.csproj
+++ b/tests/Promptly.Application.UnitTests/Promptly.Application.UnitTests.csproj
@@ -12,10 +12,10 @@
     <CoverletOutput>$(MSBuildProjectDirectory)/../../artifacts/test-results/csharp/coverage/coverage</CoverletOutput>
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <DeterministicReport>true</DeterministicReport>
-    <Include>[Promptly.Application]Promptly.Application.Services.ExpectationEvaluator,[Promptly.Application]Promptly.Application.Services.BoundedRegexMatcher,[Promptly.Application]Promptly.Application.Services.MappingService*,[Promptly.Application]Promptly.Application.Services.MappingSpecValidationException</Include>
+    <Include>[Promptly.Application]Promptly.Application.Services.ExpectationEvaluator,[Promptly.Application]Promptly.Application.Services.BoundedRegexMatcher,[Promptly.Application]Promptly.Application.Services.MappingService*,[Promptly.Application]Promptly.Application.Services.MappingSpecValidationException,[Promptly.Infrastructure]*</Include>
     <Threshold>90</Threshold>
     <ThresholdType>line,branch</ThresholdType>
-    <ThresholdStat>total</ThresholdStat>
+    <ThresholdStat>minimum</ThresholdStat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Promptly.Application.UnitTests/PythonEvalClientEdgeCaseTests.cs
+++ b/tests/Promptly.Application.UnitTests/PythonEvalClientEdgeCaseTests.cs
@@ -14,10 +14,11 @@ public sealed class PythonEvalClientEdgeCaseTests
     public void Constructor_uses_the_documented_default_worker_address_and_timeout()
     {
         var httpClient = new HttpClient(new FixedHandler(() => JsonResponse(HttpStatusCode.OK, "{}")));
+        using var configuration = new ConfigurationManager();
 
         _ = new PythonEvalClient(
             httpClient,
-            new ConfigurationManager(),
+            configuration,
             NullLogger<PythonEvalClient>.Instance);
 
         Assert.Equal(new Uri("http://localhost:8000"), httpClient.BaseAddress);
@@ -141,7 +142,7 @@ public sealed class PythonEvalClientEdgeCaseTests
 
     private static PythonEvalClient CreateClient(HttpMessageHandler handler)
     {
-        var configuration = new ConfigurationManager
+        using var configuration = new ConfigurationManager
         {
             ["PROMPTLY_EVAL_BASE_URL"] = "https://worker.example.test"
         };

--- a/tests/Promptly.Application.UnitTests/PythonEvalClientEdgeCaseTests.cs
+++ b/tests/Promptly.Application.UnitTests/PythonEvalClientEdgeCaseTests.cs
@@ -1,0 +1,166 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Promptly.Application.Interfaces;
+using Promptly.Domain.ValueObjects;
+using Promptly.Infrastructure.Clients;
+
+namespace Promptly.Application.UnitTests;
+
+public sealed class PythonEvalClientEdgeCaseTests
+{
+    [Fact]
+    public void Constructor_uses_the_documented_default_worker_address_and_timeout()
+    {
+        var httpClient = new HttpClient(new FixedHandler(() => JsonResponse(HttpStatusCode.OK, "{}")));
+
+        _ = new PythonEvalClient(
+            httpClient,
+            new ConfigurationManager(),
+            NullLogger<PythonEvalClient>.Instance);
+
+        Assert.Equal(new Uri("http://localhost:8000"), httpClient.BaseAddress);
+        Assert.Equal(TimeSpan.FromMinutes(2), httpClient.Timeout);
+    }
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("{\"reason\":\"mapping is missing\"}")]
+    public async Task Mapping_proposal_rejects_success_responses_without_a_mapping(string responseJson)
+    {
+        var client = CreateClient(new FixedHandler(() => JsonResponse(HttpStatusCode.OK, responseJson)));
+
+        var result = await client.ProposeMappingAsync(
+            "{}",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.Equal(PythonWorkerErrorCodes.InvalidResponse, result.ErrorCode);
+        Assert.Equal("Python worker returned an invalid response", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Invalid_mapping_json_is_a_typed_error_without_exposing_parser_details()
+    {
+        var client = CreateClient(new FixedHandler(() => JsonResponse(HttpStatusCode.OK, "not-json")));
+
+        var result = await client.ProposeMappingAsync(
+            "{}",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.Equal(PythonWorkerErrorCodes.InvalidResponse, result.ErrorCode);
+        Assert.Equal("Python worker returned an invalid response", result.ErrorMessage);
+    }
+
+    [Theory]
+    [InlineData("{\"detail\":\"safe string detail\"}", "safe string detail")]
+    [InlineData("{\"detail\":{\"message\":\"safe object detail\"}}", "safe object detail")]
+    [InlineData("{}", "Python worker returned HTTP 502")]
+    public async Task Groundedness_preserves_only_supported_safe_worker_errors(
+        string responseJson,
+        string expectedMessage)
+    {
+        var client = CreateClient(new FixedHandler(() => JsonResponse(HttpStatusCode.BadGateway, responseJson)));
+
+        var result = await client.EvaluateGroundednessAsync(
+            0.7,
+            new CanonicalTrace(),
+            [],
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.Equal(502, result.WorkerStatusCode);
+        Assert.Equal(PythonWorkerErrorCodes.UpstreamFailure, result.ErrorCode);
+        Assert.Equal(expectedMessage, result.ErrorMessage);
+    }
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("{\"reason\":\"missing score\"}")]
+    [InlineData("{\"score\":0.5,\"reason\":null}")]
+    [InlineData("{\"score\":-0.01,\"reason\":\"invalid\"}")]
+    [InlineData("{\"score\":1.01,\"reason\":\"invalid\"}")]
+    public async Task Groundedness_rejects_malformed_or_out_of_range_scores(string responseJson)
+    {
+        var client = CreateClient(new FixedHandler(() => JsonResponse(HttpStatusCode.OK, responseJson)));
+
+        var result = await client.EvaluateGroundednessAsync(
+            0.7,
+            new CanonicalTrace(),
+            [],
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.Equal(0, result.Score);
+        Assert.Equal(PythonWorkerErrorCodes.InvalidResponse, result.ErrorCode);
+    }
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("{\"score\":0.5,\"reason\":null}")]
+    [InlineData("{\"score\":-0.01,\"reason\":\"invalid\"}")]
+    [InlineData("{\"score\":1.01,\"reason\":\"invalid\"}")]
+    public async Task Llm_judge_rejects_missing_reasons_and_out_of_range_scores(string responseJson)
+    {
+        var client = CreateClient(new FixedHandler(() => JsonResponse(HttpStatusCode.OK, responseJson)));
+
+        var result = await client.EvaluateLlmJudgeAsync(
+            "Be accurate",
+            0.7,
+            new CanonicalTrace(),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.Equal(PythonWorkerErrorCodes.InvalidResponse, result.ErrorCode);
+    }
+
+    [Theory]
+    [InlineData("timeout", PythonWorkerErrorCodes.Timeout, "Python worker request timed out")]
+    [InlineData("client", PythonWorkerErrorCodes.ClientError, "Python worker request failed")]
+    public async Task Groundedness_maps_non_caller_cancellation_and_unexpected_client_failures(
+        string exceptionKind,
+        string expectedCode,
+        string expectedMessage)
+    {
+        var client = CreateClient(new FixedHandler(() => exceptionKind == "timeout"
+            ? throw new TaskCanceledException("secret timeout detail")
+            : throw new InvalidOperationException("secret client detail")));
+
+        var result = await client.EvaluateGroundednessAsync(
+            0.7,
+            new CanonicalTrace(),
+            [],
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(result.Success);
+        Assert.Equal(expectedCode, result.ErrorCode);
+        Assert.Equal(expectedMessage, result.ErrorMessage);
+    }
+
+    private static PythonEvalClient CreateClient(HttpMessageHandler handler)
+    {
+        var configuration = new ConfigurationManager
+        {
+            ["PROMPTLY_EVAL_BASE_URL"] = "https://worker.example.test"
+        };
+        return new PythonEvalClient(
+            new HttpClient(handler),
+            configuration,
+            NullLogger<PythonEvalClient>.Instance);
+    }
+
+    private static HttpResponseMessage JsonResponse(HttpStatusCode statusCode, string json) =>
+        new(statusCode)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+
+    private sealed class FixedHandler(Func<HttpResponseMessage> responseFactory) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) => Task.FromResult(responseFactory());
+    }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,12 +2,12 @@
 
 Promptly's automated test foundation is being added in dependency-ordered slices under issue #18.
 
-The expanding C# gate exercises the public behavior of `ExpectationEvaluator`, `BoundedRegexMatcher`, and `MappingService`, including schema-1 extraction and mapping-spec persistence validation. It fails zero-test runs and enforces at least 90% line and branch coverage for both the measured production cohort and each named production class:
+The expanding C# gate exercises the public behavior of `ExpectationEvaluator`, `BoundedRegexMatcher`, `MappingService`, and every production source file in the `Promptly.Infrastructure` assembly. It fails zero-test runs and enforces at least 90% line and branch coverage for each measured assembly and each named Application class:
 
 ```bash
 dotnet test tests/Promptly.Application.UnitTests/Promptly.Application.UnitTests.csproj --configuration Release --settings tests/Promptly.runsettings --logger "trx;LogFileName=Promptly.Application.UnitTests.trx" --results-directory artifacts/test-results/csharp
 ```
 
-The ignored `artifacts/test-results/csharp` directory receives the TRX result plus Cobertura and JSON coverage reports. GitHub Actions runs the same gate for every pull request and `main` push, verifies the exact measured assembly and source cohort, and retains those artifacts for 14 days.
+The ignored `artifacts/test-results/csharp` directory receives the TRX result plus Cobertura and JSON coverage reports. GitHub Actions runs the same gate for every pull request and `main` push, verifies the exact measured assembly and Application source cohorts plus all checked-in Infrastructure C# sources, and retains those artifacts for 14 days.
 
-This scoped gate is not evidence of repository-wide 90% coverage; issues #18 and #19 remain open until every unit-testable production area and language stack is included in the required aggregate gates.
+This expanding gate is not evidence of repository-wide 90% C# coverage; Application services outside the named cohort, Domain, Server, SDK, and CLI remain outside its denominator. Issues #18 and #19 remain open until every unit-testable production area is included in the required aggregate gates.


### PR DESCRIPTION
## Summary

- exercise every checked-in Promptly.Infrastructure production source through public behavior tests covering authentication, persistence, JWTs, encryption, YAML serialization, JSONPath evaluation, and worker-client wire/error/cancellation paths
- expand the measured C# cohort to the exact Application and Infrastructure assemblies while preserving the strict mapping class gates from #53
- reconcile every checked-in Infrastructure source against Cobertura so newly added or silently omitted production files fail CI
- enforce at least 90% line and branch coverage per measured class with Coverlet minimum statistics
- make Actions reproduce local warning-free Release builds and dotnet formatting checks
- preserve the exact seven-project vulnerability scan and required test/coverage artifact inventory
- dispose every test-owned configuration resource identified by CodeQL

## Stack

1. #48 — application regex/test foundation
2. #50 — frontend quality gate
3. #51 — worker runtime and cross-language verification
4. #52 — dependency remediation and continuous security scanning
5. #53 — strict cross-runtime mapping contracts
6. this PR — complete Infrastructure coverage cohort

Base exact head: `b09f9732963c4b733991b872cd022c3d1bb1d2d6`
This PR exact head: `5c2c1c27f83c9eae890441b14e02dece95be4b02`

## Verification

- locked .NET restore: passed
- Release warning-as-error build: 0 warnings, 0 errors
- dotnet format verification: passed
- application/infrastructure tests: 241 passed, 2 explicit opt-in live-contract skips, 0 failed
- Promptly.Application measured cohort: 96.40% line / 94.28% branch
- Promptly.Infrastructure complete assembly: 99.73% line / 99.03% branch
- lowest Infrastructure class: 97.43% line / 91.66% branch; every measured class is above 90% line and branch
- exact two-assembly, three-Application-source, all-seven-Infrastructure-source, required-Application-class, seven-project dependency-scan, and required-artifact reconciliation: passed
- .NET vulnerability scan: 0 known findings
- actionlint and git diff checks: passed
- both CodeQL disposal findings addressed with focused 18/18 and full 241/241 regression tests
- independent exact-diff audit: no findings beyond the accepted CI warning/format gap, which this branch fixes

## Tracking

Progresses #18, #19, and #47.

Issues #18 and #19 intentionally remain open because Domain, Server, SDK, CLI, integration, and end-to-end coverage still require later dependency-ordered slices. No coverage threshold was lowered and no source was excluded.