### PR TITLE
Fail closed on insecure JWT signing keys

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -87,15 +87,23 @@ If you have your own LLM service to test, you'll configure it in the UI after st
 
 ---
 
-### 4. **JWT Secret** (Already Configured ✅)
+### 4. **JWT Signing Key** (Required)
 
-The JWT secret is already set in docker-compose.yml:
+Generate a unique 48-byte key for each environment and put it in that environment's
+secret manager or untracked `docker/.env` file:
 
 ```bash
-JWT__Key=YourSuperSecretJWTKeyThatShouldBeAtLeast32CharactersLongForProduction
+openssl rand -base64 48
+# Copy the output into docker/.env:
+JWT__Key=<BASE64_OUTPUT>
 ```
 
-For development/testing, this default is fine. For production, change it to a secure random string (32+ characters).
+Promptly has no fallback signing key. Startup fails in every environment when the value is
+missing, is the historic public default, is not canonical base64, decodes to fewer than 32
+bytes, has a recognized low-entropy/predictable structure, or matches a configured retired-key
+fingerprint. A validator cannot prove how an otherwise plausible sample was generated, so
+operators must still use the documented cryptographically secure generator. Never reuse a
+development or test signing key in Production.
 
 ---
 
@@ -122,9 +130,11 @@ POSTGRES_PASSWORD=promptly_dev_password
 ConnectionStrings__Default=Host=postgres;Database=promptly;Username=promptly;Password=promptly_dev_password
 
 # ========================================
-# JWT (Leave as-is for development)
+# JWT (required; unique per environment)
 # ========================================
-JWT__Key=YourSuperSecretJWTKeyThatShouldBeAtLeast32CharactersLongForProduction
+JWT__Key=<OUTPUT_OF_OPENSSL_RAND_BASE64_48>
+# Optional comma-separated SHA-256 fingerprints of retired keys
+JWT__RetiredKeyFingerprints=
 JWT__Issuer=Promptly
 JWT__Audience=Promptly
 JWT__ExpiryMinutes=60
@@ -142,7 +152,7 @@ TestRunner__MaxConcurrentRuns=2
 
 ### **C# API (promptly-server)**
 - ✅ Database connection string (configured)
-- ✅ JWT settings (configured)
+- ⚠️ JWT signing key (YOU GENERATE and inject)
 - ✅ Data Protection path (configured)
 - ✅ Python worker URL (configured via Docker network)
 
@@ -169,12 +179,63 @@ cd docker
 docker compose up -d
 ```
 
+The Server refuses to start when `JWT__Key` is absent or empty.
+
 Wait ~30 seconds for services to start, then:
 
 - **Web UI**: http://localhost:3000
 - **API**: http://localhost:5000
 - **Swagger**: http://localhost:5000/swagger
 - **Python Worker**: internal service at `http://promptly-eval:8000`
+
+---
+
+## JWT key rotation and incident response
+
+Treat the signing key as a production secret. Prefer a per-environment secret-manager
+injection over a dotenv file; restrict read access, avoid shell history and logs, and use
+an independent key for each deployment.
+
+For a planned rotation:
+
+1. Generate a new key with `openssl rand -base64 48`. Before replacing the old value,
+   calculate its fingerprint from the authoritative secret-manager value. For the local
+   `docker/.env` path, the checked helper rejects missing, empty, duplicate, or non-canonical
+   Base64 entries, reads the value without printing it or embedding it in shell history,
+   and prints only its SHA-256 fingerprint:
+
+   ```bash
+   docker/fingerprint-jwt-key.sh docker/.env
+   ```
+
+   The first upgrade from a Promptly version that treated `JWT__Key` as literal UTF-8 text
+   must fingerprint those exact legacy bytes instead. Run the helper once in legacy mode
+   before replacing the old value, then use the default canonical-Base64 mode for every
+   later rotation:
+
+   ```bash
+   docker/fingerprint-jwt-key.sh --legacy-raw docker/.env
+   ```
+
+2. Add that 64-character digest to the comma-separated
+   `JWT__RetiredKeyFingerprints` value, inject the new `JWT__Key`, and restart every Server
+   replica together. Compose forwards both settings. Startup rejects accidental reuse of
+   any listed key.
+3. Existing JWTs immediately become invalid. Notify users that they must sign in again and
+   monitor authentication failures for expected convergence.
+4. Retain fingerprints—not old keys—in the deployment's security record.
+
+If the historic public key or any active key may have been used or disclosed, treat it as
+an authentication compromise: rotate immediately, invalidate all sessions by restarting
+on the new key, inspect authentication and sensitive-resource access logs from the exposure
+window, notify affected operators/users, and rotate downstream credentials that may have
+been exposed. Never commit the replacement key.
+
+HMAC remains the only supported signing mode in this release because Promptly currently
+issues and validates its own tokens. First-class asymmetric signing requires a separately
+designed issuer/trust and rotation contract; do not assume an external identity provider is
+compatible until that integration exists and is tested. Environments requiring independent
+signer/verifier custody should treat that missing integration as a deployment blocker.
 
 ---
 
@@ -257,5 +318,5 @@ curl -X POST http://localhost:5000/demo/chat \
 ## 📧 Need Help?
 
 1. Check logs: `docker compose logs <service-name>`
-2. Verify configuration: `docker compose config`
+2. Verify configuration without printing resolved secrets: `docker compose config --quiet`
 3. Restart services: `docker compose restart`

--- a/DesignSpec.md
+++ b/DesignSpec.md
@@ -509,7 +509,10 @@ Data retention:
 
 ## C# control plane env vars
 - ConnectionStrings__Default
-- JWT__Issuer, JWT__Audience, JWT__Key
+- JWT__Issuer, JWT__Audience, JWT__Key (required secret-manager value containing at least
+  32 random bytes encoded as canonical base64)
+- JWT__RetiredKeyFingerprints (optional comma-separated SHA-256 fingerprints preventing
+  retired-key reuse)
 - DATA_PROTECTION_PATH
 - PROMPTLY_EVAL_BASE_URL (e.g., http://promptly-eval:8000)
 

--- a/PROVIDE_THESE_VALUES.md
+++ b/PROVIDE_THESE_VALUES.md
@@ -16,6 +16,9 @@ PROMPTLY_LLM_PROVIDER=azureopenai
 PROMPTLY_LLM_API_KEY=________________________
 PROMPTLY_LLM_AZURE_ENDPOINT=________________________
 PROMPTLY_LLM_MODEL_DEFAULT=________________________
+
+# Generate with: openssl rand -base64 48
+JWT__Key=________________________
 ```
 
 ### Where to get these values:
@@ -83,7 +86,7 @@ The PostgreSQL database:
 
 | File/Location | What | Status |
 |---------------|------|--------|
-| `docker/.env` | Azure OpenAI credentials | ⚠️ **YOU CREATE THIS** |
+| `docker/.env` | Azure OpenAI credentials and a unique JWT signing key | ⚠️ **YOU CREATE THIS** |
 | `docker/docker-compose.yml` | Service configuration | ✅ Already configured |
 | `docker/.env.example` | Template file | ✅ Reference available |
 | Database | PostgreSQL | ✅ Auto-configured in Docker |
@@ -121,11 +124,12 @@ docker compose exec promptly-eval python -c \
 
 **Minimum required to start testing:**
 1. Create `docker/.env`
-2. Add 3 Azure OpenAI values (key, endpoint, deployment name)
+2. Add 3 Azure OpenAI values and a unique `JWT__Key`
 3. Run `docker compose up -d`
 4. Open http://localhost:3000
 
-**That's it!** Everything else is pre-configured.
+Everything else is pre-configured. Promptly intentionally refuses to start without the JWT
+key; see `CONFIGURATION.md` for generation, rotation, and incident response.
 
 ---
 
@@ -139,7 +143,7 @@ docker compose exec promptly-eval python -c \
 
 ## 🚀 I'm Ready to Test!
 
-Once you provide these values, I can:
+Once you provide the provider values and configure the signing key locally, I can:
 - ✅ Start the entire system with `docker compose up`
 - ✅ Test LLM judge evaluations
 - ✅ Test mapping proposal (AI-powered)
@@ -147,9 +151,11 @@ Once you provide these values, I can:
 - ✅ Run end-to-end test scenarios
 - ✅ Verify all components work together
 
-**Please provide:**
+**Please provide or configure as indicated:**
 1. Your Azure OpenAI API key
 2. Your Azure OpenAI endpoint
 3. Your deployment name
+4. Configure a unique JWT signing key locally in `docker/.env` or your secret manager with
+   `openssl rand -base64 48`; do not provide it to another person or commit it
 
 And let me know if you want to use the built-in demo endpoint or if you have your own service to test against!

--- a/Promptly.Infrastructure/Configuration/JwtSettings.cs
+++ b/Promptly.Infrastructure/Configuration/JwtSettings.cs
@@ -1,9 +1,10 @@
 namespace Promptly.Infrastructure.Configuration;
 
-public class JwtSettings
+public sealed class JwtSettings
 {
-    public required string Issuer { get; set; }
-    public required string Audience { get; set; }
-    public required string Key { get; set; }
+    public string Issuer { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string Key { get; set; } = string.Empty;
     public int ExpiryMinutes { get; set; } = 60;
+    public string RetiredKeyFingerprints { get; set; } = string.Empty;
 }

--- a/Promptly.Infrastructure/Configuration/JwtSettingsValidator.cs
+++ b/Promptly.Infrastructure/Configuration/JwtSettingsValidator.cs
@@ -1,0 +1,257 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Options;
+
+namespace Promptly.Infrastructure.Configuration;
+
+public sealed class JwtSettingsValidator : IValidateOptions<JwtSettings>
+{
+    public const int MinimumSigningKeyBytes = 32;
+    public const int MaximumExpiryMinutes = 1440;
+    public const double MinimumEstimatedEntropyBitsPerByte = 4.0;
+
+    private const string PublishedLegacyKey =
+        "YourSuperSecretJWTKeyThatShouldBeAtLeast32CharactersLongForProduction";
+    private const string Base64Alphabet =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    private const int PredictableBase64RunLength = 8;
+    private static readonly byte[] PublishedLegacyKeyBytes = Encoding.UTF8.GetBytes(PublishedLegacyKey);
+
+    public ValidateOptionsResult Validate(string? name, JwtSettings options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var failures = new List<string>();
+        if (string.IsNullOrWhiteSpace(options.Issuer))
+        {
+            failures.Add("JWT:Issuer is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Audience))
+        {
+            failures.Add("JWT:Audience is required.");
+        }
+
+        if (options.ExpiryMinutes is < 1 or > MaximumExpiryMinutes)
+        {
+            failures.Add($"JWT:ExpiryMinutes must be between 1 and {MaximumExpiryMinutes}.");
+        }
+
+        var keyBytes = ValidateSigningKey(options.Key, failures);
+        ValidateRetiredKeyFingerprints(options.RetiredKeyFingerprints, keyBytes, failures);
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+
+    public static byte[] GetValidatedSigningKeyBytes(JwtSettings options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var validation = new JwtSettingsValidator().Validate(Options.DefaultName, options);
+        if (validation.Failed)
+        {
+            throw new OptionsValidationException(
+                Options.DefaultName,
+                typeof(JwtSettings),
+                validation.Failures);
+        }
+
+        return Convert.FromBase64String(options.Key);
+    }
+
+    public static string GetSigningKeyId(ReadOnlySpan<byte> signingKey) =>
+        Convert.ToHexString(SHA256.HashData(signingKey)).ToLowerInvariant()[..16];
+
+    private static byte[]? ValidateSigningKey(string key, ICollection<string> failures)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            failures.Add(
+                "JWT:Key is required and must be injected as canonical base64-encoded random bytes.");
+            return null;
+        }
+
+        if (string.Equals(key, PublishedLegacyKey, StringComparison.Ordinal))
+        {
+            failures.Add("JWT:Key is the published legacy key and must be rotated.");
+            return null;
+        }
+
+        byte[] keyBytes;
+        try
+        {
+            keyBytes = Convert.FromBase64String(key);
+        }
+        catch (FormatException)
+        {
+            failures.Add("JWT:Key must be canonical base64 without whitespace.");
+            return null;
+        }
+
+        if (!string.Equals(Convert.ToBase64String(keyBytes), key, StringComparison.Ordinal))
+        {
+            failures.Add("JWT:Key must be canonical base64 without whitespace.");
+            return null;
+        }
+
+        if (CryptographicOperations.FixedTimeEquals(keyBytes, PublishedLegacyKeyBytes))
+        {
+            failures.Add("JWT:Key decodes to the published legacy key and must be rotated.");
+            return null;
+        }
+
+        if (keyBytes.Length < MinimumSigningKeyBytes)
+        {
+            failures.Add(
+                $"JWT:Key must decode to at least {MinimumSigningKeyBytes} random bytes.");
+            return null;
+        }
+
+        if (HasPredictableEncodedPattern(key)
+            || HasPredictablePattern(keyBytes)
+            || EstimateEntropyBitsPerByte(keyBytes) < MinimumEstimatedEntropyBitsPerByte)
+        {
+            failures.Add(
+                "JWT:Key is low entropy or predictably structured; " +
+                "generate it with a cryptographically secure generator.");
+            return null;
+        }
+
+        return keyBytes;
+    }
+
+    private static void ValidateRetiredKeyFingerprints(
+        string? retiredFingerprints,
+        byte[]? currentKey,
+        ICollection<string> failures)
+    {
+        var currentFingerprint = currentKey is null
+            ? null
+            : Convert.ToHexString(SHA256.HashData(currentKey));
+        var fingerprints = (retiredFingerprints ?? string.Empty).Split(
+            ',',
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        for (var index = 0; index < fingerprints.Length; index++)
+        {
+            var fingerprint = fingerprints[index];
+            if (fingerprint.Length != 64 || !fingerprint.All(Uri.IsHexDigit))
+            {
+                failures.Add(
+                    $"JWT:RetiredKeyFingerprints entry {index} must be a 64-character " +
+                    "SHA-256 hex digest.");
+            }
+            else if (string.Equals(fingerprint, currentFingerprint, StringComparison.OrdinalIgnoreCase))
+            {
+                failures.Add("JWT:Key matches a retired key fingerprint and must not be reused.");
+            }
+        }
+    }
+
+    private static bool HasPredictablePattern(byte[] bytes) =>
+        bytes.All(value => value is >= 0x20 and <= 0x7e)
+        || IsArithmeticProgression(bytes)
+        || HasRepeatedBlock(bytes);
+
+    private static bool HasPredictableEncodedPattern(string key)
+    {
+        var symbolCount = key.EndsWith("==", StringComparison.Ordinal)
+            ? key.Length - 2
+            : key.EndsWith('=')
+                ? key.Length - 1
+                : key.Length;
+        var previous = Base64Alphabet.IndexOf(key[0], StringComparison.Ordinal);
+        int? delta = null;
+        var runLength = 1;
+        for (var index = 1; index < symbolCount; index++)
+        {
+            var current = Base64Alphabet.IndexOf(key[index], StringComparison.Ordinal);
+            var currentDelta = (current - previous + Base64Alphabet.Length) % Base64Alphabet.Length;
+            if (delta == currentDelta)
+            {
+                runLength++;
+                if (runLength >= PredictableBase64RunLength)
+                {
+                    return true;
+                }
+            }
+            else
+            {
+                delta = currentDelta;
+                runLength = 2;
+            }
+
+            previous = current;
+        }
+
+        return false;
+    }
+
+    private static bool IsArithmeticProgression(byte[] bytes)
+    {
+        var delta = unchecked((byte)(bytes[1] - bytes[0]));
+        for (var index = 2; index < bytes.Length; index++)
+        {
+            if (unchecked((byte)(bytes[index] - bytes[index - 1])) != delta)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool HasRepeatedBlock(byte[] bytes)
+    {
+        for (var blockLength = 1; blockLength <= bytes.Length / 2; blockLength++)
+        {
+            if (bytes.Length % blockLength != 0)
+            {
+                continue;
+            }
+
+            var repeats = true;
+            for (var index = blockLength; index < bytes.Length; index++)
+            {
+                if (bytes[index] == bytes[index % blockLength])
+                {
+                    continue;
+                }
+
+                repeats = false;
+                break;
+            }
+
+            if (repeats)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static double EstimateEntropyBitsPerByte(byte[] bytes)
+    {
+        Span<int> frequencies = stackalloc int[256];
+        foreach (var value in bytes)
+        {
+            frequencies[value]++;
+        }
+
+        var entropy = 0.0;
+        foreach (var frequency in frequencies)
+        {
+            if (frequency == 0)
+            {
+                continue;
+            }
+
+            var probability = (double)frequency / bytes.Length;
+            entropy -= probability * Math.Log2(probability);
+        }
+
+        return entropy;
+    }
+}

--- a/Promptly.Infrastructure/Services/JwtService.cs
+++ b/Promptly.Infrastructure/Services/JwtService.cs
@@ -1,6 +1,5 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
-using System.Text;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using Promptly.Application.Interfaces;
@@ -12,10 +11,12 @@ namespace Promptly.Infrastructure.Services;
 public class JwtService : IJwtService
 {
     private readonly JwtSettings _jwtSettings;
+    private readonly byte[] _signingKey;
 
     public JwtService(IOptions<JwtSettings> jwtSettings)
     {
         _jwtSettings = jwtSettings.Value;
+        _signingKey = JwtSettingsValidator.GetValidatedSigningKeyBytes(_jwtSettings);
     }
 
     public string GenerateToken(User user)
@@ -28,7 +29,10 @@ public class JwtService : IJwtService
             new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
         };
 
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtSettings.Key));
+        var key = new SymmetricSecurityKey(_signingKey)
+        {
+            KeyId = JwtSettingsValidator.GetSigningKeyId(_signingKey)
+        };
         var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
         var token = new JwtSecurityToken(

--- a/Promptly.Server/Program.cs
+++ b/Promptly.Server/Program.cs
@@ -1,10 +1,10 @@
-using System.Text;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.Extensions.Options;
 using Promptly.Application.Interfaces;
 using Promptly.Application.Services;
 using Promptly.Domain.Entities;
@@ -64,8 +64,13 @@ builder.Services.AddIdentity<User, IdentityRole>(options =>
 .AddDefaultTokenProviders();
 
 // Configure JWT
-var jwtSettings = builder.Configuration.GetSection("JWT").Get<JwtSettings>()!;
-builder.Services.Configure<JwtSettings>(builder.Configuration.GetSection("JWT"));
+var jwtSection = builder.Configuration.GetSection("JWT");
+var jwtSettings = jwtSection.Get<JwtSettings>() ?? new JwtSettings();
+var jwtSigningKey = JwtSettingsValidator.GetValidatedSigningKeyBytes(jwtSettings);
+builder.Services.AddOptions<JwtSettings>()
+    .Bind(jwtSection)
+    .ValidateOnStart();
+builder.Services.AddSingleton<IValidateOptions<JwtSettings>, JwtSettingsValidator>();
 builder.Services.AddScoped<IJwtService, JwtService>();
 
 // Configure Authentication
@@ -84,7 +89,10 @@ builder.Services.AddAuthentication(options =>
         ValidateIssuerSigningKey = true,
         ValidIssuer = jwtSettings.Issuer,
         ValidAudience = jwtSettings.Audience,
-        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSettings.Key))
+        IssuerSigningKey = new SymmetricSecurityKey(jwtSigningKey)
+        {
+            KeyId = JwtSettingsValidator.GetSigningKeyId(jwtSigningKey)
+        }
     };
 })
 .AddScheme<AuthenticationSchemeOptions, ApiKeyAuthenticationHandler>("ApiKey", null);

--- a/Promptly.Server/appsettings.json
+++ b/Promptly.Server/appsettings.json
@@ -13,7 +13,6 @@
   "JWT": {
     "Issuer": "Promptly",
     "Audience": "Promptly",
-    "Key": "YourSuperSecretJWTKeyThatShouldBeAtLeast32CharactersLongForProduction",
     "ExpiryMinutes": 60
   },
   "DATA_PROTECTION_PATH": "./dataprotection-keys",

--- a/Promptly.Worker/scripts/verify.py
+++ b/Promptly.Worker/scripts/verify.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
+import os
+import secrets
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 import xml.etree.ElementTree as ET
@@ -19,7 +24,12 @@ IMAGE_TAG = "promptly-worker:verification"
 MINIMUM_COVERAGE = 0.90
 
 
-def run(command: list[str], *, capture: bool = False) -> str:
+def run(
+    command: list[str],
+    *,
+    capture: bool = False,
+    environment: dict[str, str] | None = None,
+) -> str:
     """Run a command from the worker directory and stop on any failure."""
 
     print(f"+ {' '.join(command)}", flush=True)
@@ -29,6 +39,7 @@ def run(command: list[str], *, capture: bool = False) -> str:
         check=True,
         text=True,
         stdout=subprocess.PIPE if capture else None,
+        env=environment,
     )
     return completed.stdout.strip() if capture else ""
 
@@ -206,19 +217,75 @@ def assert_summary(path: Path) -> None:
 
 
 def assert_compose_isolation() -> None:
-    compose_json = run(
-        [
-            "docker",
-            "compose",
-            "--file",
-            str(REPOSITORY_ROOT / "docker" / "docker-compose.yml"),
-            "config",
-            "--format",
-            "json",
-        ],
-        capture=True,
-    )
+    compose_file = str(REPOSITORY_ROOT / "docker" / "docker-compose.yml")
+    environment = os.environ.copy()
+    environment.pop("JWT__Key", None)
+    environment.pop("JWT__RetiredKeyFingerprints", None)
+    verification_key = base64.b64encode(secrets.token_bytes(48)).decode("ascii")
+    retired_fingerprint = "a" * 64
+
+    with tempfile.TemporaryDirectory(prefix="promptly-compose-verification-") as temp_dir:
+        empty_env_file = Path(temp_dir) / "missing.env"
+        empty_env_file.write_text("", encoding="utf-8")
+        empty_key_env_file = Path(temp_dir) / "empty.env"
+        empty_key_env_file.write_text("JWT__Key=\n", encoding="utf-8")
+        valid_env_file = Path(temp_dir) / "valid.env"
+        valid_env_file.write_text(
+            f"JWT__Key={verification_key}\nJWT__RetiredKeyFingerprints={retired_fingerprint}\n",
+            encoding="utf-8",
+        )
+
+        for key_case, env_file in (
+            ("missing", empty_env_file),
+            ("empty", empty_key_env_file),
+        ):
+            compose_command = [
+                "docker",
+                "compose",
+                "--env-file",
+                str(env_file),
+                "--file",
+                compose_file,
+                "config",
+            ]
+            rejected = subprocess.run(
+                [*compose_command, "--quiet"],
+                cwd=WORKER_ROOT,
+                check=False,
+                text=True,
+                capture_output=True,
+                env=environment,
+            )
+            if rejected.returncode == 0 or "JWT__Key must be set" not in rejected.stderr:
+                raise RuntimeError(f"Compose must reject a {key_case} JWT signing key")
+
+        compose_json = run(
+            [
+                "docker",
+                "compose",
+                "--env-file",
+                str(valid_env_file),
+                "--file",
+                compose_file,
+                "config",
+                "--format",
+                "json",
+            ],
+            capture=True,
+            environment=environment,
+        )
     services = json.loads(compose_json)["services"]
+    server_environment = services["promptly-server"]["environment"]
+    if "JWT__Key" not in server_environment:
+        raise RuntimeError("Compose must forward the injected JWT signing key")
+    if "JWT__RetiredKeyFingerprints" not in server_environment:
+        raise RuntimeError("Compose must forward retired JWT key fingerprints")
+    if server_environment["JWT__Key"] != verification_key:
+        raise RuntimeError("Compose must forward the exact injected JWT signing key")
+    if server_environment["JWT__RetiredKeyFingerprints"] != retired_fingerprint:
+        raise RuntimeError("Compose must forward the exact retired JWT key fingerprints")
+    if server_environment["JWT__Key"].startswith("YourSuperSecretJWTKey"):
+        raise RuntimeError("Compose must not contain the published legacy JWT signing key")
     worker = services["promptly-eval"]
     if worker.get("ports"):
         raise RuntimeError("Compose must not publish the worker port to the host")
@@ -227,6 +294,73 @@ def assert_compose_isolation() -> None:
     dependency = services["promptly-server"]["depends_on"]["promptly-eval"]
     if dependency["condition"] != "service_healthy":
         raise RuntimeError("The server must wait for a healthy worker")
+
+
+def assert_jwt_rotation_helper() -> None:
+    helper = REPOSITORY_ROOT / "docker" / "fingerprint-jwt-key.sh"
+    verification_key_bytes = secrets.token_bytes(48)
+    verification_key = base64.b64encode(verification_key_bytes).decode("ascii")
+
+    with tempfile.TemporaryDirectory(prefix="promptly-jwt-rotation-verification-") as temp_dir:
+        absent_env_file = Path(temp_dir) / "absent.env"
+        absent = subprocess.run(
+            ["bash", str(helper), str(absent_env_file)],
+            cwd=REPOSITORY_ROOT,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        if absent.returncode == 0:
+            raise RuntimeError("JWT rotation helper must reject a missing environment file")
+
+        valid_env_file = Path(temp_dir) / "valid.env"
+        valid_env_file.write_text(f"JWT__Key={verification_key}\n", encoding="utf-8")
+        valid = subprocess.run(
+            ["bash", str(helper), str(valid_env_file)],
+            cwd=REPOSITORY_ROOT,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        expected_fingerprint = hashlib.sha256(verification_key_bytes).hexdigest()
+        if valid.returncode != 0 or valid.stdout.strip() != expected_fingerprint:
+            raise RuntimeError("JWT rotation helper must fingerprint canonical key bytes exactly")
+
+        legacy = subprocess.run(
+            ["bash", str(helper), "--legacy-raw", str(valid_env_file)],
+            cwd=REPOSITORY_ROOT,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        expected_legacy_fingerprint = hashlib.sha256(verification_key.encode("ascii")).hexdigest()
+        if legacy.returncode != 0 or legacy.stdout.strip() != expected_legacy_fingerprint:
+            raise RuntimeError("JWT rotation helper must fingerprint legacy literal key bytes")
+        if legacy.stdout.strip() == valid.stdout.strip():
+            raise RuntimeError("Legacy and canonical JWT fingerprints must use distinct bytes")
+
+        invalid_cases = {
+            "missing": "PROMPTLY_LLM_PROVIDER=openai\n",
+            "empty": "JWT__Key=\n",
+            "duplicate": f"JWT__Key={verification_key}\nJWT__Key={verification_key}\n",
+            "malformed": "JWT__Key=not-base64\n",
+            "invalid-characters": "JWT__Key=!!!!\n",
+            "trailing-junk": "JWT__Key=YWJjZA==junk\n",
+        }
+        for key_case, contents in invalid_cases.items():
+            invalid_env_file = Path(temp_dir) / f"{key_case}.env"
+            invalid_env_file.write_text(contents, encoding="utf-8")
+            rejected = subprocess.run(
+                ["bash", str(helper), str(invalid_env_file)],
+                cwd=REPOSITORY_ROOT,
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+            if rejected.returncode == 0:
+                raise RuntimeError(f"JWT rotation helper must reject a {key_case} key entry")
+            if verification_key in rejected.stdout or verification_key in rejected.stderr:
+                raise RuntimeError("JWT rotation helper must not disclose signing key material")
 
 
 def assert_image_sources(sources: list[Path]) -> str:
@@ -556,6 +690,7 @@ def main() -> None:
     )
 
     summary = assert_tool_artifacts(sources)
+    assert_jwt_rotation_helper()
     assert_compose_isolation()
     run(
         [

--- a/README.md
+++ b/README.md
@@ -106,7 +106,19 @@ That process is part of what Promptly is meant to demonstrate. The repository is
    PROMPTLY_LLM_MODEL_DEFAULT=gpt-4o-mini
    ```
 
-   **Database and other settings are pre-configured** - see `SETUP_CHECKLIST.md` for details.
+   Generate a unique JWT signing key and add it to the same untracked `docker/.env` file:
+
+   ```bash
+   if grep -q '^JWT__Key=' docker/.env; then
+     echo "docker/.env already contains JWT__Key; replace that single value explicitly" >&2
+     exit 1
+   fi
+   printf 'JWT__Key=%s\n' "$(openssl rand -base64 48)" >> docker/.env
+   ```
+
+   Promptly intentionally refuses to render the Compose service or start the Server when
+   this key is missing or insecure. Database settings remain pre-configured; see
+   `CONFIGURATION.md` for JWT rotation/incident response and `SETUP_CHECKLIST.md` for details.
 
 3. **Start all services**
    ```bash
@@ -131,10 +143,13 @@ That process is part of what Promptly is meant to demonstrate. The repository is
 Configuration via `appsettings.json` or environment variables:
 
 - **ConnectionStrings:Default**: PostgreSQL connection string
-- **JWT:Key**: Secret key for JWT signing (min 32 characters)
+- **JWT:Key**: Required canonical-base64 JWT signing key (at least 32 decoded random bytes;
+  generate a unique per-environment value with `openssl rand -base64 48`)
 - **JWT:Issuer**: JWT issuer
 - **JWT:Audience**: JWT audience
 - **JWT:ExpiryMinutes**: Token expiry time (default: 60)
+- **JWT:RetiredKeyFingerprints**: Optional comma-separated SHA-256 fingerprints of retired
+  signing keys; startup rejects reuse (see `CONFIGURATION.md` for rotation and incident response)
 - **DATA_PROTECTION_PATH**: Path for Data Protection keys persistence
 - **PROMPTLY_EVAL_BASE_URL**: Python worker base URL
 - **TestRunner:PollingIntervalSeconds**: Background worker polling interval (default: 5)

--- a/SETUP_CHECKLIST.md
+++ b/SETUP_CHECKLIST.md
@@ -11,6 +11,7 @@ PROMPTLY_LLM_PROVIDER=azureopenai
 PROMPTLY_LLM_API_KEY=___________________  # ← PASTE YOUR KEY HERE
 PROMPTLY_LLM_AZURE_ENDPOINT=___________________  # ← PASTE YOUR ENDPOINT HERE
 PROMPTLY_LLM_MODEL_DEFAULT=___________________  # ← YOUR DEPLOYMENT NAME HERE
+JWT__Key=___________________  # ← OUTPUT OF: openssl rand -base64 48
 ```
 
 **Where to find these:**
@@ -85,13 +86,14 @@ Open: http://localhost:5000/swagger
 | **Azure Endpoint** | `docker/.env` | ⚠️ YOU PROVIDE |
 | **Deployment Name** | `docker/.env` | ⚠️ YOU PROVIDE |
 | **Database** | Docker container | ✅ AUTO-CONFIGURED |
-| **JWT Secret** | `docker-compose.yml` | ✅ CONFIGURED (dev default) |
+| **JWT signing key** | untracked `docker/.env` / secret manager | ⚠️ YOU GENERATE |
 | **Test Endpoint** | Built-in or UI | ✅ BUILT-IN DEMO AVAILABLE |
 
 ---
 
 ## That's It!
 
-You only need to provide **3 values** (Azure OpenAI credentials). Everything else is already configured.
+Provide the three Azure OpenAI values plus a unique JWT signing key. Promptly fails startup
+if the key is missing or insecure; see `CONFIGURATION.md` for rotation guidance.
 
 See `CONFIGURATION.md` for detailed explanation of each setting.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -7,7 +7,10 @@ POSTGRES_PASSWORD=your_secure_password_here
 ConnectionStrings__Default=Host=postgres;Database=promptly;Username=promptly;Password=your_secure_password_here
 
 # JWT Configuration
-JWT__Key=YourSuperSecretJWTKeyThatShouldBeAtLeast32CharactersLongForProduction
+# Required. Generate a unique value for each environment with: openssl rand -base64 48
+JWT__Key=
+# Optional comma-separated SHA-256 fingerprints of retired keys; never put old keys here.
+JWT__RetiredKeyFingerprints=
 JWT__Issuer=Promptly
 JWT__Audience=Promptly
 JWT__ExpiryMinutes=60

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,7 +29,8 @@ services:
       - ConnectionStrings__Default=Host=postgres;Database=promptly;Username=promptly;Password=promptly_dev_password
       - JWT__Issuer=Promptly
       - JWT__Audience=Promptly
-      - JWT__Key=YourSuperSecretJWTKeyThatShouldBeAtLeast32CharactersLongForProduction
+      - JWT__Key=${JWT__Key:?JWT__Key must be set to base64-encoded random bytes}
+      - JWT__RetiredKeyFingerprints=${JWT__RetiredKeyFingerprints:-}
       - JWT__ExpiryMinutes=60
       - DATA_PROTECTION_PATH=/app/dataprotection-keys
       - PROMPTLY_EVAL_BASE_URL=http://promptly-eval:8000

--- a/docker/fingerprint-jwt-key.sh
+++ b/docker/fingerprint-jwt-key.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mode="base64"
+if [[ "${1:-}" == "--legacy-raw" ]]; then
+  mode="legacy-raw"
+  shift
+fi
+
+env_file="${1:-docker/.env}"
+if [[ ! -f "$env_file" ]]; then
+  echo "$env_file does not exist" >&2
+  exit 1
+fi
+
+jwt_key_count=$(awk '/^JWT__Key=/{count++} END{print count+0}' "$env_file")
+if [[ "$jwt_key_count" -ne 1 ]]; then
+  echo "$env_file must contain exactly one JWT__Key entry; found $jwt_key_count" >&2
+  exit 1
+fi
+
+retired_jwt_key=$(sed -n 's/^JWT__Key=//p' "$env_file")
+if [[ -z "$retired_jwt_key" ]]; then
+  echo "$env_file has an empty JWT__Key value" >&2
+  exit 1
+fi
+
+if [[ "$mode" == "legacy-raw" ]]; then
+  printf '%s' "$retired_jwt_key" |
+    openssl dgst -sha256 -r |
+    awk '{print $1}'
+else
+  canonical_jwt_key=$(
+    printf '%s' "$retired_jwt_key" |
+      openssl base64 -d -A |
+      openssl base64 -A
+  )
+  if [[ "$canonical_jwt_key" != "$retired_jwt_key" ]]; then
+    echo "$env_file JWT__Key is not canonical base64" >&2
+    unset retired_jwt_key canonical_jwt_key
+    exit 1
+  fi
+  unset canonical_jwt_key
+
+  printf '%s' "$retired_jwt_key" |
+    openssl base64 -d -A |
+    openssl dgst -sha256 -r |
+    awk '{print $1}'
+fi
+unset retired_jwt_key

--- a/tests/Promptly.Application.UnitTests/InfrastructureServiceTests.cs
+++ b/tests/Promptly.Application.UnitTests/InfrastructureServiceTests.cs
@@ -1,6 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
-using System.Text;
+using System.Security.Cryptography;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -62,7 +62,7 @@ public sealed class JwtServiceTests
         {
             Issuer = "promptly-tests",
             Audience = "promptly-clients",
-            Key = "unit-test-signing-key-that-is-at-least-32-bytes",
+            Key = Convert.ToBase64String(RandomNumberGenerator.GetBytes(48)),
             ExpiryMinutes = 15
         };
         var service = new JwtService(Options.Create(settings));
@@ -86,7 +86,7 @@ public sealed class JwtServiceTests
                 ValidAudience = settings.Audience,
                 ValidateLifetime = true,
                 ValidateIssuerSigningKey = true,
-                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(settings.Key)),
+                IssuerSigningKey = new SymmetricSecurityKey(Convert.FromBase64String(settings.Key)),
                 ClockSkew = TimeSpan.Zero
             },
             out var validatedToken);

--- a/tests/Promptly.Application.UnitTests/JwtSettingsValidatorTests.cs
+++ b/tests/Promptly.Application.UnitTests/JwtSettingsValidatorTests.cs
@@ -1,0 +1,272 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Options;
+using Promptly.Infrastructure.Configuration;
+
+namespace Promptly.Application.UnitTests;
+
+public sealed class JwtSettingsValidatorTests
+{
+    private const string PublishedLegacyKey =
+        "YourSuperSecretJWTKeyThatShouldBeAtLeast32CharactersLongForProduction";
+
+    private readonly JwtSettingsValidator _validator = new();
+
+    [Fact]
+    public void Secure_configuration_succeeds_and_returns_the_decoded_key()
+    {
+        var keyBytes = DiverseKeyBytes();
+        var settings = SecureSettings(keyBytes);
+
+        var result = _validator.Validate(Options.DefaultName, settings);
+        var decoded = JwtSettingsValidator.GetValidatedSigningKeyBytes(settings);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(keyBytes, decoded);
+        Assert.Equal(16, JwtSettingsValidator.GetSigningKeyId(decoded).Length);
+    }
+
+    [Theory]
+    [InlineData(32)]
+    [InlineData(34)]
+    public void Secure_padded_configuration_succeeds(int byteCount)
+    {
+        var settings = SecureSettings(DiverseKeyBytes()[..byteCount]);
+
+        var result = _validator.Validate(Options.DefaultName, settings);
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Missing_identity_key_and_invalid_expiry_fail_together()
+    {
+        var settings = new JwtSettings
+        {
+            Issuer = " ",
+            Audience = string.Empty,
+            Key = string.Empty,
+            ExpiryMinutes = 0
+        };
+
+        var result = _validator.Validate(Options.DefaultName, settings);
+
+        Assert.True(result.Failed);
+        AssertFailure(result, "JWT:Issuer is required.");
+        AssertFailure(result, "JWT:Audience is required.");
+        AssertFailure(
+            result,
+            "JWT:Key is required and must be injected as canonical base64-encoded random bytes.");
+        AssertFailure(result, "JWT:ExpiryMinutes must be between 1 and 1440.");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1441)]
+    public void Expiry_outside_the_bounded_range_fails(int expiryMinutes)
+    {
+        var settings = SecureSettings();
+        settings.ExpiryMinutes = expiryMinutes;
+
+        var result = _validator.Validate(Options.DefaultName, settings);
+
+        AssertFailure(result, "JWT:ExpiryMinutes must be between 1 and 1440.");
+    }
+
+    [Fact]
+    public void Published_legacy_text_key_is_rejected()
+    {
+        var settings = SecureSettings();
+        settings.Key = PublishedLegacyKey;
+
+        var result = _validator.Validate(Options.DefaultName, settings);
+
+        AssertFailure(result, "JWT:Key is the published legacy key and must be rotated.");
+    }
+
+    [Fact]
+    public void Base64_encoded_legacy_key_material_is_rejected()
+    {
+        var settings = SecureSettings();
+        settings.Key = Convert.ToBase64String(Encoding.UTF8.GetBytes(PublishedLegacyKey));
+
+        var result = _validator.Validate(Options.DefaultName, settings);
+
+        AssertFailure(
+            result,
+            "JWT:Key decodes to the published legacy key and must be rotated.");
+    }
+
+    [Theory]
+    [InlineData("not-base64")]
+    [InlineData("AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=\n")]
+    public void Malformed_or_noncanonical_base64_is_rejected(string key)
+    {
+        var settings = SecureSettings();
+        settings.Key = key;
+
+        var result = _validator.Validate(Options.DefaultName, settings);
+
+        AssertFailure(result, "JWT:Key must be canonical base64 without whitespace.");
+    }
+
+    [Fact]
+    public void Key_shorter_than_256_bits_is_rejected()
+    {
+        var settings = SecureSettings();
+        settings.Key = Convert.ToBase64String(DiverseKeyBytes()[..31]);
+
+        var result = _validator.Validate(Options.DefaultName, settings);
+
+        AssertFailure(result, "JWT:Key must decode to at least 32 random bytes.");
+    }
+
+    [Fact]
+    public void Low_entropy_key_is_rejected_even_when_long_enough()
+    {
+        var settings = SecureSettings();
+        settings.Key = Convert.ToBase64String(
+            [.. Enumerable.Range(0, 48).Select(index => (byte)(index % 5))]);
+
+        var result = _validator.Validate(Options.DefaultName, settings);
+
+        AssertFailure(
+            result,
+            "JWT:Key is low entropy or predictably structured; " +
+            "generate it with a cryptographically secure generator.");
+    }
+
+    [Theory]
+    [MemberData(nameof(PredictableKeys))]
+    public void Predictably_structured_key_is_rejected_despite_length_and_byte_diversity(
+        byte[] keyBytes)
+    {
+        var settings = SecureSettings();
+        settings.Key = Convert.ToBase64String(keyBytes);
+
+        var result = _validator.Validate(Options.DefaultName, settings);
+
+        AssertFailure(
+            result,
+            "JWT:Key is low entropy or predictably structured; " +
+            "generate it with a cryptographically secure generator.");
+    }
+
+    [Theory]
+    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")]
+    [InlineData("/+9876543210zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA")]
+    public void Predictable_base64_symbol_sequence_is_rejected(string key)
+    {
+        var settings = SecureSettings();
+        settings.Key = key;
+
+        var result = _validator.Validate(Options.DefaultName, settings);
+
+        AssertFailure(
+            result,
+            "JWT:Key is low entropy or predictably structured; " +
+            "generate it with a cryptographically secure generator.");
+    }
+
+    public static TheoryData<byte[]> PredictableKeys => new()
+    {
+        { [.. Enumerable.Range(0, 32).Select(index => (byte)index)] },
+        { Encoding.UTF8.GetBytes("this human-readable signing key is not random material") },
+        { [.. Enumerable.Repeat(new byte[] { 0x00, 0xff, 0x11, 0xee }, 12)
+            .SelectMany(block => block)] }
+    };
+
+    [Fact]
+    public void Retired_fingerprint_blocks_key_reuse_case_insensitively()
+    {
+        var keyBytes = DiverseKeyBytes();
+        var settings = SecureSettings(keyBytes);
+        settings.RetiredKeyFingerprints = string.Join(
+            ", ",
+            new string('a', 64),
+            Convert.ToHexString(SHA256.HashData(keyBytes)).ToLowerInvariant());
+
+        var result = _validator.Validate(Options.DefaultName, settings);
+
+        AssertFailure(result, "JWT:Key matches a retired key fingerprint and must not be reused.");
+    }
+
+    [Fact]
+    public void Invalid_retired_fingerprint_is_rejected_even_when_the_current_key_is_invalid()
+    {
+        var settings = SecureSettings();
+        settings.Key = string.Empty;
+        settings.RetiredKeyFingerprints = "not-a-sha256-fingerprint";
+
+        var result = _validator.Validate(Options.DefaultName, settings);
+
+        AssertFailure(
+            result,
+            "JWT:RetiredKeyFingerprints entry 0 must be a 64-character SHA-256 hex digest.");
+    }
+
+    [Fact]
+    public void A_different_valid_retired_fingerprint_does_not_block_startup()
+    {
+        var settings = SecureSettings();
+        settings.RetiredKeyFingerprints = new string('a', 64);
+
+        var result = _validator.Validate(Options.DefaultName, settings);
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" , ")]
+    public void Blank_retired_fingerprint_list_is_treated_as_empty(string? fingerprints)
+    {
+        var settings = SecureSettings();
+        settings.RetiredKeyFingerprints = fingerprints!;
+
+        var result = _validator.Validate(Options.DefaultName, settings);
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Invalid_configuration_throws_without_disclosing_key_material()
+    {
+        var settings = SecureSettings();
+        settings.Key = "secret-but-invalid";
+
+        var exception = Assert.Throws<OptionsValidationException>(() =>
+            JwtSettingsValidator.GetValidatedSigningKeyBytes(settings));
+
+        Assert.Contains("JWT:Key must be canonical base64", exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(settings.Key, exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Null_options_are_rejected_by_both_entry_points()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            _validator.Validate(Options.DefaultName, null!));
+        Assert.Throws<ArgumentNullException>(() =>
+            JwtSettingsValidator.GetValidatedSigningKeyBytes(null!));
+    }
+
+    private static JwtSettings SecureSettings(byte[]? keyBytes = null) => new()
+    {
+        Issuer = "promptly-tests",
+        Audience = "promptly-clients",
+        Key = Convert.ToBase64String(keyBytes ?? DiverseKeyBytes()),
+        ExpiryMinutes = 60
+    };
+
+    private static byte[] DiverseKeyBytes() =>
+        SHA512.HashData(Encoding.UTF8.GetBytes("Promptly JWT validator deterministic test vector"))[..48];
+
+    private static void AssertFailure(ValidateOptionsResult result, string expected)
+    {
+        Assert.True(result.Failed);
+        Assert.NotNull(result.Failures);
+        Assert.Contains(expected, result.Failures);
+    }
+}

--- a/tests/Promptly.IntegrationTests/JwtConfigurationStartupTests.cs
+++ b/tests/Promptly.IntegrationTests/JwtConfigurationStartupTests.cs
@@ -1,0 +1,129 @@
+using System.Net;
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace Promptly.IntegrationTests;
+
+public sealed class JwtConfigurationStartupTests
+{
+    private const string PublishedLegacyKey =
+        "YourSuperSecretJWTKeyThatShouldBeAtLeast32CharactersLongForProduction";
+
+    [Theory]
+    [InlineData("Development", "missing", "JWT:Key is required")]
+    [InlineData("Test", "legacy", "JWT:Key is the published legacy key")]
+    [InlineData("Production", "low-entropy", "JWT:Key is low entropy")]
+    [InlineData("Production", "retired", "JWT:Key matches a retired key fingerprint")]
+    public void Insecure_key_fails_before_host_startup(
+        string environment,
+        string keyCase,
+        string expectedFailure)
+    {
+        var secureKeyBytes = RandomNumberGenerator.GetBytes(48);
+        var key = keyCase switch
+        {
+            "missing" => null,
+            "legacy" => PublishedLegacyKey,
+            "low-entropy" => Convert.ToBase64String(new byte[48]),
+            "retired" => Convert.ToBase64String(secureKeyBytes),
+            _ => throw new ArgumentOutOfRangeException(nameof(keyCase))
+        };
+        var retiredFingerprints = keyCase == "retired"
+            ? Convert.ToHexString(SHA256.HashData(secureKeyBytes))
+            : null;
+        using var factory = new JwtConfigurationFactory(environment, key, retiredFingerprints);
+
+        var exception = Record.Exception(() =>
+        {
+            using var client = factory.CreateClient();
+        });
+
+        Assert.NotNull(exception);
+        Assert.Contains(
+            Flatten(exception),
+            failure => failure.Message.Contains(expectedFailure, StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("Development")]
+    [InlineData("Test")]
+    [InlineData("Production")]
+    public async Task Secure_injected_key_starts_a_healthy_host(string environment)
+    {
+        var key = Convert.ToBase64String(RandomNumberGenerator.GetBytes(48));
+        using var factory = new JwtConfigurationFactory(environment, key, retiredFingerprints: null);
+        using var client = factory.CreateClient();
+
+        using var response = await client.GetAsync(
+            "/health",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    private static IEnumerable<Exception> Flatten(Exception exception)
+    {
+        yield return exception;
+        if (exception is AggregateException aggregate)
+        {
+            foreach (var inner in aggregate.InnerExceptions.SelectMany(Flatten))
+            {
+                yield return inner;
+            }
+        }
+        else if (exception.InnerException is not null)
+        {
+            foreach (var inner in Flatten(exception.InnerException))
+            {
+                yield return inner;
+            }
+        }
+    }
+
+    private sealed class JwtConfigurationFactory : WebApplicationFactory<Program>
+    {
+        private readonly string _environment;
+        private readonly string? _key;
+        private readonly string? _retiredFingerprints;
+        private readonly string _temporaryRoot = Path.Join(
+            Path.GetTempPath(),
+            "promptly-jwt-configuration-tests",
+            Guid.NewGuid().ToString("N"));
+
+        public JwtConfigurationFactory(
+            string environment,
+            string? key,
+            string? retiredFingerprints)
+        {
+            _environment = environment;
+            _key = key;
+            _retiredFingerprints = retiredFingerprints;
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder
+                .UseEnvironment(_environment)
+                .UseSetting("ConnectionStrings:Default", "Host=unused;Database=unused")
+                .UseSetting("JWT:Issuer", $"Promptly.{_environment}.Tests")
+                .UseSetting("JWT:Audience", $"Promptly.{_environment}.Tests")
+                .UseSetting("JWT:Key", _key ?? string.Empty)
+                .UseSetting("JWT:RetiredKeyFingerprints", _retiredFingerprints ?? string.Empty)
+                .UseSetting("JWT:ExpiryMinutes", "10")
+                .UseSetting("DATA_PROTECTION_PATH", Path.Join(_temporaryRoot, "keys"))
+                .UseSetting("PROMPTLY_EVAL_BASE_URL", "http://127.0.0.1:1")
+                .UseSetting("Startup:ApplyDatabaseMigrations", "false")
+                .UseSetting("TestRunner:Enabled", "false");
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (disposing && Directory.Exists(_temporaryRoot))
+            {
+                Directory.Delete(_temporaryRoot, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,6 +23,8 @@ Covered foundation contracts include:
 - owned suite YAML import persistence (semantic YAML export round-tripping remains tracked separately in issue #44);
 - real mapping proposal across Server, FastAPI, and the provider stub;
 - safe Server responses when the worker is unavailable or returns malformed JSON.
+- fail-closed JWT configuration in Development, test, and Production, plus healthy startup
+  with an injected high-entropy signing key.
 
 The suite intentionally does not assert current cross-tenant behavior of nested resources. Those authorization contracts belong after issue #26 closes, so this foundation does not canonize a known vulnerability.
 


### PR DESCRIPTION
## Summary

- remove usable JWT signing material from committed settings, Compose, and templates
- require a canonical Base64 key containing at least 32 bytes and reject missing, historic-default, short, predictably structured, low-entropy, or retired key material before host startup
- use the same decoded key bytes and stable key ID for issuance and validation
- forward the required key and retired-key fingerprints through Compose without a fallback
- add an executable rotation helper with distinct canonical-Base64 and legacy-literal migration modes, strict validation, and no secret output
- document per-environment generation, rotation, compromise response, and the current HMAC-only custody constraint
- add unit, startup-integration, Compose, and rotation-helper regression coverage

## Stack

1. #48 — application regex/test foundation
2. #50 — frontend quality gate
3. #51 — worker runtime and cross-language verification
4. #52 — dependency remediation and continuous security scanning
5. #53 — strict cross-runtime mapping contracts
6. #54 — complete Infrastructure coverage cohort
7. #55 — real-stack integration verification
8. this PR — fail-closed JWT signing configuration

Base exact head: `9c8bb5f6a1e1540f8d2a99b3ea4915f666513999`
This PR exact head: `bc4773d23d65154ce90d81121f4d57f6e4fff474`

## Verification

- Release warning-as-error build: 0 warnings, 0 errors
- dotnet format and git diff checks: passed
- application/infrastructure unit tests: 266 passed, 2 explicit opt-in live-contract skips, 0 failed
- Application measured cohort: 96.40% line / 94.28% branch
- Infrastructure complete assembly: 99.79% line / 99.44% branch
- JwtSettings, JwtSettingsValidator, and JwtService: 100% line / 100% branch
- real-stack integration suite: 17 passed, 0 failed, 0 skipped
- authoritative worker verifier: 167 passed; 98.78% line / 98.82% branch
- live C# to FastAPI contracts: 2 passed, 0 skipped
- isolated Compose contracts: missing and empty keys rejected; exact key and retired fingerprints forwarded
- rotation-helper contracts: exact canonical and legacy fingerprints; missing file/value, duplicate, malformed, invalid-character, and trailing-junk inputs rejected
- .NET, runtime Python, and verification Python vulnerability inventories: no findings on this stacked head
- two independent final audits: clean after live remediation of rotation and predictable-key edge cases

## Scope notes

HMAC is the only supported JWT mode in this release. A deployment that requires independent signer/verifier custody remains blocked until a first-class asymmetric issuer/trust contract is implemented and tested.

## Tracking

Progresses #29 and #47. Issue #29 intentionally remains open until the change reaches the default branch and deployment rotation evidence can be recorded. No security finding or coverage threshold was waived.