### PR TITLE
test: make run polling regression deterministic

### DIFF
--- a/Promptly.Web/src/web/src/pages/RunDetail.test.tsx
+++ b/Promptly.Web/src/web/src/pages/RunDetail.test.tsx
@@ -205,21 +205,20 @@ describe('RunDetail', () => {
     const queuedRun = { ...completedRun, status: 'Running', summaryJson: undefined };
     vi.mocked(runsApi.getById).mockResolvedValue(queuedRun);
     vi.mocked(runsApi.getResults).mockResolvedValue([]);
-    let poll: (() => void) | undefined;
-    vi.spyOn(globalThis, 'setInterval').mockImplementation(((handler: TimerHandler, timeout?: number) => {
-      if (typeof handler === 'function' && timeout === 5000) {
-        poll = () => handler();
-      }
-      return 1;
-    }) as typeof setInterval);
-    renderDetail();
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+    const view = renderDetail();
 
     expect(await screen.findByText('Running')).toBeInTheDocument();
-    await waitFor(() => expect(poll).toBeDefined());
-    const pollCallback = poll;
-    expect(pollCallback).toBeDefined();
-    await act(async () => pollCallback?.());
+    await waitFor(() => expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 5000));
+    const pollCallback = setIntervalSpy.mock.calls.find(([, timeout]) => timeout === 5000)?.[0];
+    expect(pollCallback).toBeTypeOf('function');
+    await act(async () => {
+      if (typeof pollCallback === 'function') {
+        pollCallback();
+      }
+    });
     await waitFor(() => expect(runsApi.getById).toHaveBeenCalledTimes(2));
+    view.unmount();
   });
 
   it('renders the load error after an initial request failure', async () => {


### PR DESCRIPTION
## Summary

- preserve Testing Library's real scheduler while observing the component's interval registration
- select and invoke the exact 5-second RunDetail polling callback
- explicitly unmount the component so the real interval is cleared
- retain the public-behavior assertion that polling performs a second API fetch

## Why

Web verification on PR #66 exposed a scheduler race in the existing test. Its global `setInterval` stub also replaced Testing Library's 50 ms `waitFor` retry interval. The DOM could render `Running` before React registered the component's polling effect, after which no timer or DOM mutation could retry the assertion.

This is intentionally a one-file test-only repair; production polling behavior is unchanged.

## Exact ancestry

- Base branch: `codex/64-auth-concurrency`
- Base head: `1f0796dfe7d2633b337b7740379e69385a1222e6`
- PR head: `4c5ef8035cb3fc85c36eb3b954fcd03b71a49705`

## Verification

- locked install: 0 vulnerabilities
- focused polling regression: repeated independent process stress passed
- typecheck: passed
- lint: passed with zero warnings
- unit/coverage gate: 151/151 passed
- coverage: 97.59% line / 92.56% branch
- full and production npm audits: 0 vulnerabilities
- release build: passed
- diff check: clean

The existing bundle-size warning remains owned by #49; this slice does not change production bundles.

Closes #69
Refs #19