### PR TITLE
[P0][E2E] Add production-composed Playwright auth gate

### DIFF
--- a/.github/workflows/e2e-verification.yml
+++ b/.github/workflows/e2e-verification.yml
@@ -1,0 +1,57 @@
+name: E2E verification
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-verification-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-verification:
+    name: E2E verification
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    defaults:
+      run:
+        working-directory: Promptly.Web/src/web
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version-file: Promptly.Web/src/web/.node-version
+          cache: npm
+          cache-dependency-path: Promptly.Web/src/web/package-lock.json
+
+      - name: Install locked test dependencies
+        run: npm ci
+
+      - name: Install pinned Chromium runtime
+        run: npx playwright install --with-deps chromium
+
+      - name: Run production-composed browser gate
+        env:
+          CI: "true"
+        run: npm run test:e2e
+
+      - name: Upload browser and Compose evidence
+        if: ${{ !cancelled() && hashFiles('artifacts/test-results/e2e/upload-safe.json') != '' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-test-results
+          path: artifacts/test-results/e2e
+          if-no-files-found: error
+          retention-days: 14

--- a/Promptly.Server/Dockerfile
+++ b/Promptly.Server/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.302 AS build
 WORKDIR /src
 
 # Copy project files

--- a/Promptly.Web/src/web/.dockerignore
+++ b/Promptly.Web/src/web/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+coverage
+playwright-report
+test-results
+npm-debug.log

--- a/Promptly.Web/src/web/Dockerfile
+++ b/Promptly.Web/src/web/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:22.22.2-alpine3.23 AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM nginxinc/nginx-unprivileged:1.29.4-alpine AS runtime
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=5s --timeout=3s --start-period=5s --retries=12 \
+  CMD wget --quiet --output-document=- http://127.0.0.1:8080/healthz >/dev/null || exit 1

--- a/Promptly.Web/src/web/e2e/README.md
+++ b/Promptly.Web/src/web/e2e/README.md
@@ -25,10 +25,10 @@ npm run test:e2e
 `npm run test:e2e` is the only supported entry point. It generates unique
 Compose project state, high-entropy database/JWT secrets, and free loopback web
 and API ports; builds the static web, Production server, worker, provider stub,
-and egress proxy; waits with fixed bounds; runs the exact required-test inventory;
-collects evidence; and unconditionally removes the containers, networks, volumes,
-and per-run images. It never calls a reset endpoint and never uses production
-credentials.
+egress proxy, and dedicated host-ingress gateway; waits with fixed bounds; runs
+the exact required-test inventory; collects evidence; and unconditionally removes
+the containers, networks, volumes, and per-run images. It never calls a reset
+endpoint and never uses production credentials.
 
 Artifacts are written under `artifacts/test-results/e2e`:
 
@@ -39,7 +39,7 @@ Artifacts are written under `artifacts/test-results/e2e`:
 
 Upload finalization recursively inspects retained trace ZIP contents and scrubs
 generated bearer tokens/passwords plus per-run Compose secrets before creating the
-`upload-safe.json` marker. Nested or oversized archives fail closed.
+`upload-safe.json` marker. Nested, duplicate-entry, or oversized archives fail closed.
 
 ## Retry and quarantine policy
 
@@ -55,8 +55,10 @@ test failures. The expired-session test registers the single expected 401 before
 triggering it and must observe that exact response.
 
 The topology gate first proves its globally routed canary is reachable through the
-allowed egress proxy and that each direct-egress probe is executable with a
-same-container control-network connection. It then requires an exact bounded-timeout
-contract to that same canary without the proxy. The host-ingress network has IPv6
-disabled and IPv4 masquerading disabled; arbitrary command failures are not accepted
-as egress-isolation evidence.
+allowed egress proxy and that each server, web, and evaluation-worker workload can
+use its internal control network. Those workloads belong only to that Docker-internal
+network; their IPv4 and IPv6 route tables must contain no default Internet route. A
+dedicated, read-only gateway is the sole member that bridges the control and
+host-ingress networks and publishes the two loopback ports. The host-ingress network
+has IPv6 disabled and IPv4 masquerading disabled, while only the egress proxy joins
+the globally routed egress network.

--- a/Promptly.Web/src/web/e2e/README.md
+++ b/Promptly.Web/src/web/e2e/README.md
@@ -37,6 +37,10 @@ Artifacts are written under `artifacts/test-results/e2e`:
 - sanitized provider requests, Compose logs/state/images, topology and cleanup
   attestations, runner log, and run metadata.
 
+The runner ignores inherited Playwright reporter selection and blob, HTML, JSON,
+JUnit, and last-run output-path overrides so those artifacts cannot be redirected
+outside the fixed repository artifact root.
+
 Upload finalization recursively inspects retained trace ZIP contents and scrubs
 generated bearer tokens/passwords plus per-run Compose secrets before creating the
 `upload-safe.json` marker. Nested, duplicate-entry, or oversized archives fail closed.

--- a/Promptly.Web/src/web/e2e/README.md
+++ b/Promptly.Web/src/web/e2e/README.md
@@ -1,0 +1,62 @@
+# Production-composed browser verification
+
+This gate proves only the currently implemented authentication/session boundary:
+
+- anonymous protected-route redirect;
+- browser registration, Projects arrival, logout, and login through the real API;
+- a deterministically expired, test-signed JWT receiving a real protected-API 401,
+  redirecting to login, and clearing both stored auth entries.
+
+It does not claim the remaining project-to-result, CRUD/navigation, demo, or
+mapping journeys tracked by #24 and their product blockers.
+
+## Exact local command
+
+Prerequisites are Docker with Compose, Node from `.node-version`, and the pinned
+Chromium runtime:
+
+```sh
+cd Promptly.Web/src/web
+npm ci
+npx playwright install chromium
+npm run test:e2e
+```
+
+`npm run test:e2e` is the only supported entry point. It generates unique
+Compose project state, high-entropy database/JWT secrets, and free loopback web
+and API ports; builds the static web, Production server, worker, provider stub,
+and egress proxy; waits with fixed bounds; runs the exact required-test inventory;
+collects evidence; and unconditionally removes the containers, networks, volumes,
+and per-run images. It never calls a reset endpoint and never uses production
+credentials.
+
+Artifacts are written under `artifacts/test-results/e2e`:
+
+- `junit.xml`, `results.json`, `verification.json`, and `html/index.html`;
+- retained failure traces, screenshots, and videos under `playwright-output`;
+- sanitized provider requests, Compose logs/state/images, topology and cleanup
+  attestations, runner log, and run metadata.
+
+Upload finalization recursively inspects retained trace ZIP contents and scrubs
+generated bearer tokens/passwords plus per-run Compose secrets before creating the
+`upload-safe.json` marker. Nested or oversized archives fail closed.
+
+## Retry and quarantine policy
+
+Retries are zero. Required tests may not be focused, skipped, fixed, marked as
+expected failures, tagged, quarantined, flaky, duplicated, omitted, or added
+without updating `required-tests.json`. The verifier fails closed on any drift.
+If a product defect blocks a required journey, open and link an issue, repair the
+defect, and keep the test required; do not hide it with retries or quarantine.
+
+The browser guard permits only the generated web origin and treats page errors,
+console errors, request failures, unapproved HTTP failures, and browser egress as
+test failures. The expired-session test registers the single expected 401 before
+triggering it and must observe that exact response.
+
+The topology gate first proves its globally routed canary is reachable through the
+allowed egress proxy and that each direct-egress probe is executable with a
+same-container control-network connection. It then requires an exact bounded-timeout
+contract to that same canary without the proxy. The host-ingress network has IPv6
+disabled and IPv4 masquerading disabled; arbitrary command failures are not accepted
+as egress-isolation evidence.

--- a/Promptly.Web/src/web/e2e/auth.e2e.ts
+++ b/Promptly.Web/src/web/e2e/auth.e2e.ts
@@ -68,7 +68,7 @@ test('registration logout and login traverse the real stack', async ({ page }) =
   await page.getByRole('button', { name: 'Sign Up' }).click();
   expect((await registration).status()).toBe(200);
   await expect(page).toHaveURL(/\/$/);
-  await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Projects', exact: true })).toBeVisible();
   await expect(page.getByText('No projects yet')).toBeVisible();
   await expect.poll(() => page.evaluate(() => ({
     hasToken: localStorage.getItem('auth_token') !== null,
@@ -92,7 +92,7 @@ test('registration logout and login traverse the real stack', async ({ page }) =
   await page.getByRole('button', { name: 'Sign In' }).click();
   expect((await login).status()).toBe(200);
   await expect(page).toHaveURL(/\/$/);
-  await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Projects', exact: true })).toBeVisible();
   await expect.poll(() => page.evaluate(() => ({
     hasToken: localStorage.getItem('auth_token') !== null,
     hasUser: localStorage.getItem('user') !== null,

--- a/Promptly.Web/src/web/e2e/auth.e2e.ts
+++ b/Promptly.Web/src/web/e2e/auth.e2e.ts
@@ -1,0 +1,136 @@
+import { createHash, createHmac, randomUUID } from 'node:crypto';
+import { expect, test } from './fixtures';
+
+const requiredEnvironment = (name: string): string => {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required; run npm run test:e2e`);
+  }
+  return value;
+};
+
+const base64UrlJson = (value: object): string => (
+  Buffer.from(JSON.stringify(value)).toString('base64url')
+);
+
+const createExpiredToken = (): string => {
+  const signingKey = Buffer.from(requiredEnvironment('PROMPTLY_E2E_JWT_KEY'), 'base64');
+  const now = Math.floor(Date.now() / 1000);
+  const userId = randomUUID();
+  const header = base64UrlJson({
+    alg: 'HS256',
+    kid: createHash('sha256').update(signingKey).digest('hex').slice(0, 16),
+    typ: 'JWT',
+  });
+  const payload = base64UrlJson({
+    aud: 'Promptly-E2E',
+    email: 'expired-session@promptly.invalid',
+    exp: now - 600,
+    iat: now - 1_200,
+    iss: 'Promptly-E2E',
+    jti: randomUUID(),
+    nbf: now - 1_200,
+    sub: userId,
+    'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier': userId,
+  });
+  const signature = createHmac('sha256', signingKey)
+    .update(`${header}.${payload}`)
+    .digest('base64url');
+  return `${header}.${payload}.${signature}`;
+};
+
+test('anonymous protected routes redirect to login', async ({ page }) => {
+  await page.goto('/projects/00000000-0000-0000-0000-000000000000');
+
+  await expect(page).toHaveURL(/\/login$/);
+  await expect(page.getByRole('heading', { name: 'Sign in to your account' })).toBeVisible();
+  await expect.poll(() => page.evaluate(() => ({
+    token: localStorage.getItem('auth_token'),
+    user: localStorage.getItem('user'),
+  }))).toEqual({ token: null, user: null });
+});
+
+test('registration logout and login traverse the real stack', async ({ page }) => {
+  const unique = randomUUID();
+  const email = `e2e-${unique}@promptly.invalid`;
+  const password = `Promptly-${unique}-A1`;
+
+  await page.goto('/register');
+  await page.getByLabel('Full Name').fill('E2E User');
+  await page.getByLabel('Email Address').fill(email);
+  await page.getByLabel(/^Password/).fill(password);
+  await page.getByLabel('Confirm Password').fill(password);
+
+  const registration = page.waitForResponse((response) => (
+    response.request().method() === 'POST'
+      && new URL(response.url()).pathname === '/api/auth/register'
+  ));
+  await page.getByRole('button', { name: 'Sign Up' }).click();
+  expect((await registration).status()).toBe(200);
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible();
+  await expect(page.getByText('No projects yet')).toBeVisible();
+  await expect.poll(() => page.evaluate(() => ({
+    hasToken: localStorage.getItem('auth_token') !== null,
+    hasUser: localStorage.getItem('user') !== null,
+  }))).toEqual({ hasToken: true, hasUser: true });
+
+  await page.getByRole('button', { name: 'account of current user' }).click();
+  await page.getByRole('menuitem', { name: 'Logout' }).click();
+  await expect(page).toHaveURL(/\/login$/);
+  await expect.poll(() => page.evaluate(() => ({
+    token: localStorage.getItem('auth_token'),
+    user: localStorage.getItem('user'),
+  }))).toEqual({ token: null, user: null });
+
+  await page.getByLabel('Email Address').fill(email);
+  await page.getByLabel('Password').fill(password);
+  const login = page.waitForResponse((response) => (
+    response.request().method() === 'POST'
+      && new URL(response.url()).pathname === '/api/auth/login'
+  ));
+  await page.getByRole('button', { name: 'Sign In' }).click();
+  expect((await login).status()).toBe(200);
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.getByRole('heading', { name: 'Projects' })).toBeVisible();
+  await expect.poll(() => page.evaluate(() => ({
+    hasToken: localStorage.getItem('auth_token') !== null,
+    hasUser: localStorage.getItem('user') !== null,
+  }))).toEqual({ hasToken: true, hasUser: true });
+});
+
+test(
+  'an expired signed session receives 401 and clears stored authentication',
+  async ({ page, expectedHttpFailures }) => {
+    const token = createExpiredToken();
+    const storedUser = {
+      id: randomUUID(),
+      name: 'Expired E2E User',
+      email: 'expired-session@promptly.invalid',
+    };
+    expectedHttpFailures.push({ method: 'GET', path: '/api/projects', status: 401 });
+    await page.goto('/login');
+    await expect(page.getByRole('heading', { name: 'Sign in to your account' })).toBeVisible();
+    await page.evaluate(({ expiredToken, user }) => {
+      localStorage.setItem('auth_token', expiredToken);
+      localStorage.setItem('user', JSON.stringify(user));
+    }, { expiredToken: token, user: storedUser });
+
+    const unauthorized = page.waitForResponse((response) => (
+      response.request().method() === 'GET'
+        && new URL(response.url()).pathname === '/api/projects'
+        && response.status() === 401
+    ));
+    await page.goto('/');
+    const response = await unauthorized;
+
+    expect(response.status()).toBe(401);
+    expect(await response.request().headerValue('authorization')).toBe(`Bearer ${token}`);
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.getByRole('heading', { name: 'Sign in to your account' })).toBeVisible();
+    await expect.poll(() => page.evaluate(() => ({
+      token: localStorage.getItem('auth_token'),
+      user: localStorage.getItem('user'),
+    }))).toEqual({ token: null, user: null });
+  },
+);

--- a/Promptly.Web/src/web/e2e/fixtures.ts
+++ b/Promptly.Web/src/web/e2e/fixtures.ts
@@ -1,0 +1,137 @@
+import { expect, test as base, type Page } from '@playwright/test';
+
+interface ExpectedHttpFailure {
+  method: string;
+  path: string;
+  status: number;
+}
+
+interface BrowserGuardFixtures {
+  expectedHttpFailures: ExpectedHttpFailure[];
+  browserGuard: void;
+}
+
+const formatHttpFailure = ({ method, path, status }: ExpectedHttpFailure): string => (
+  `${method.toUpperCase()} ${path} ${status}`
+);
+
+export const test = base.extend<BrowserGuardFixtures>({
+  expectedHttpFailures: async ({ browserName }, use) => {
+    if (browserName !== 'chromium') {
+      throw new Error(`Unsupported E2E browser: ${browserName}`);
+    }
+    await use([]);
+  },
+
+  browserGuard: [async ({ context, page, baseURL, expectedHttpFailures }, use, testInfo) => {
+    if (!baseURL) {
+      throw new Error('Playwright baseURL is required');
+    }
+
+    const allowedOrigin = new URL(baseURL).origin;
+    const allowedWebSocketOrigin = allowedOrigin
+      .replace(/^http:/, 'ws:')
+      .replace(/^https:/, 'wss:');
+    const violations: string[] = [];
+    const consoleErrors: string[] = [];
+    const observedHttpFailures: ExpectedHttpFailure[] = [];
+
+    context.on('request', (request) => {
+      const requestUrl = new URL(request.url());
+      if (
+        (requestUrl.protocol === 'http:' || requestUrl.protocol === 'https:')
+        && requestUrl.origin !== allowedOrigin
+      ) {
+        violations.push(`Unexpected browser egress: ${request.method()} ${request.url()}`);
+      }
+    });
+
+    context.on('requestfailed', (request) => {
+      violations.push(
+        `Browser request failed: ${request.method()} ${request.url()} `
+        + `(${request.failure()?.errorText ?? 'unknown error'})`,
+      );
+    });
+
+    context.on('response', (response) => {
+      if (response.status() < 400) {
+        return;
+      }
+
+      const responseUrl = new URL(response.url());
+      observedHttpFailures.push({
+        method: response.request().method(),
+        path: `${responseUrl.pathname}${responseUrl.search}`,
+        status: response.status(),
+      });
+    });
+
+    const guardedPages = new WeakSet<Page>();
+    const guardPage = (guardedPage: Page) => {
+      if (guardedPages.has(guardedPage)) {
+        return;
+      }
+      guardedPages.add(guardedPage);
+      guardedPage.on('console', (message) => {
+        if (message.type() === 'error') {
+          consoleErrors.push(message.text());
+        }
+      });
+      guardedPage.on('pageerror', (error) => {
+        violations.push(`Uncaught page error: ${error.message}`);
+      });
+      guardedPage.on('websocket', (webSocket) => {
+        const webSocketUrl = new URL(webSocket.url());
+        if (
+          (webSocketUrl.protocol !== 'ws:' && webSocketUrl.protocol !== 'wss:')
+          || webSocketUrl.origin !== allowedWebSocketOrigin
+        ) {
+          violations.push(`Unexpected browser WebSocket egress: ${webSocket.url()}`);
+        }
+        webSocket.on('socketerror', (error) => {
+          violations.push(`Browser WebSocket failed: ${webSocket.url()} (${error})`);
+        });
+      });
+    };
+
+    guardPage(page);
+    context.on('page', guardPage);
+
+    await use();
+
+    const expected = expectedHttpFailures.map(formatHttpFailure).sort();
+    const observed = observedHttpFailures.map(formatHttpFailure).sort();
+    if (JSON.stringify(expected) !== JSON.stringify(observed)) {
+      violations.push(
+        `HTTP failure inventory mismatch: expected=${JSON.stringify(expected)} `
+        + `observed=${JSON.stringify(observed)}`,
+      );
+    }
+
+    let expectedUnauthorizedConsoleErrors = expectedHttpFailures.filter(
+      ({ status }) => status === 401,
+    ).length;
+    for (const message of consoleErrors) {
+      if (
+        expectedUnauthorizedConsoleErrors > 0
+        && message === 'Failed to load resource: the server responded with a status of 401 (Unauthorized)'
+      ) {
+        expectedUnauthorizedConsoleErrors -= 1;
+      } else {
+        violations.push(`Browser console error: ${message}`);
+      }
+    }
+
+    if (violations.length > 0) {
+      const diagnostic = `${violations.join('\n')}\n`;
+      await testInfo.attach('browser-guard-violations', {
+        body: diagnostic,
+        contentType: 'text/plain',
+      });
+      throw new Error(diagnostic);
+    }
+  }, { auto: true }],
+});
+
+export { expect };
+export type { ExpectedHttpFailure };

--- a/Promptly.Web/src/web/e2e/harness-safety.mjs
+++ b/Promptly.Web/src/web/e2e/harness-safety.mjs
@@ -32,6 +32,23 @@ const runErrorCategoryOrder = [
   'artifact verification',
   'artifact safety',
 ];
+const playwrightWritableEnvironmentKeys = new Set([
+  'PLAYWRIGHT_BLOB_OUTPUT_DIR',
+  'PLAYWRIGHT_BLOB_OUTPUT_FILE',
+  'PLAYWRIGHT_BLOB_OUTPUT_NAME',
+  'PLAYWRIGHT_HTML_OUTPUT_DIR',
+  'PLAYWRIGHT_HTML_OUTPUT_FILE',
+  'PLAYWRIGHT_HTML_OUTPUT_NAME',
+  'PLAYWRIGHT_HTML_REPORT',
+  'PLAYWRIGHT_JSON_OUTPUT_DIR',
+  'PLAYWRIGHT_JSON_OUTPUT_FILE',
+  'PLAYWRIGHT_JSON_OUTPUT_NAME',
+  'PLAYWRIGHT_JUNIT_OUTPUT_DIR',
+  'PLAYWRIGHT_JUNIT_OUTPUT_FILE',
+  'PLAYWRIGHT_JUNIT_OUTPUT_NAME',
+  'PLAYWRIGHT_LAST_RUN_OUTPUT_FILE',
+  'PW_TEST_REPORTER',
+]);
 
 export const resolveFixedE2EPaths = (moduleUrl) => {
   const e2eRoot = path.dirname(fileURLToPath(moduleUrl));
@@ -79,6 +96,17 @@ export const createSafeRunMetadata = ({
     errorCount,
     errorCategories: safeCategories,
   };
+};
+
+export const createPlaywrightEnvironment = (parentEnvironment, requiredValues) => {
+  const environment = {
+    ...parentEnvironment,
+    ...requiredValues,
+  };
+  for (const key of playwrightWritableEnvironmentKeys) {
+    delete environment[key];
+  }
+  return environment;
 };
 
 const equalLengthMask = (label, length) => {

--- a/Promptly.Web/src/web/e2e/harness-safety.mjs
+++ b/Promptly.Web/src/web/e2e/harness-safety.mjs
@@ -1,3 +1,5 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { unzipSync, zipSync } from 'fflate';
 
 const DEFAULT_MAX_ARCHIVE_BYTES = 256 * 1024 * 1024;
@@ -18,6 +20,66 @@ const credentialPatterns = [
 ];
 const htmlArchivePrefix = '<template id="playwrightReportBase64">data:application/zip;base64,';
 const htmlArchiveSuffix = '</template>';
+const runErrorCategoryOrder = [
+  'verification',
+  'diagnostics',
+  'provider diagnostics',
+  'cleanup',
+  'cleanup evidence',
+  'termination',
+  'runner log',
+  'artifact sanitization',
+  'artifact verification',
+  'artifact safety',
+];
+
+export const resolveFixedE2EPaths = (moduleUrl) => {
+  const e2eRoot = path.dirname(fileURLToPath(moduleUrl));
+  const webRoot = path.dirname(e2eRoot);
+  const repositoryRoot = path.resolve(webRoot, '../../..');
+  return Object.freeze({
+    artifactsRoot: path.join(repositoryRoot, 'artifacts/test-results/e2e'),
+    e2eRoot,
+    repositoryRoot,
+    webRoot,
+  });
+};
+
+export const createSafeRunMetadata = ({
+  completedAt,
+  errorCategories,
+  errorCount,
+  startedAt,
+}) => {
+  if (!(startedAt instanceof Date) || Number.isNaN(startedAt.valueOf())) {
+    throw new Error('Run metadata requires a valid start time');
+  }
+  if (!(completedAt instanceof Date) || Number.isNaN(completedAt.valueOf())) {
+    throw new Error('Run metadata requires a valid completion time');
+  }
+  if (!Number.isSafeInteger(errorCount) || errorCount < 0) {
+    throw new Error('Run metadata requires a nonnegative integer error count');
+  }
+
+  const requestedCategories = new Set(
+    Array.isArray(errorCategories) ? errorCategories : [],
+  );
+  const safeCategories = runErrorCategoryOrder.filter((category) => (
+    requestedCategories.has(category)
+  ));
+  if ([...requestedCategories].some((category) => !runErrorCategoryOrder.includes(category))) {
+    safeCategories.push('unclassified');
+  }
+
+  return {
+    schema: 1,
+    startedAt: startedAt.toISOString(),
+    completedAt: completedAt.toISOString(),
+    status: errorCount === 0 ? 'passed' : 'failed',
+    errorCount,
+    errorCategories: safeCategories,
+  };
+};
 
 const equalLengthMask = (label, length) => {
   const marker = `[REDACTED-${label}]`;

--- a/Promptly.Web/src/web/e2e/harness-safety.mjs
+++ b/Promptly.Web/src/web/e2e/harness-safety.mjs
@@ -118,8 +118,13 @@ export const createArtifactSanitizer = (
       throw new Error(`Compressed artifact exceeds ${maxArchiveBytes} bytes`);
     }
     let expandedBytes = 0;
+    const entryNames = new Set();
     const entries = unzipSync(archive, {
       filter: (entry) => {
+        if (entryNames.has(entry.name)) {
+          throw new Error(`Compressed artifact contains a duplicate entry: ${entry.name}`);
+        }
+        entryNames.add(entry.name);
         expandedBytes += entry.originalSize;
         if (expandedBytes > maxArchiveBytes) {
           throw new Error(`Expanded artifact exceeds ${maxArchiveBytes} bytes`);
@@ -127,6 +132,12 @@ export const createArtifactSanitizer = (
         return true;
       },
     });
+    if (
+      Object.keys(entries).length !== entryNames.size
+      || [...entryNames].some((name) => !Object.hasOwn(entries, name))
+    ) {
+      throw new Error('Compressed artifact entry inventory is not safely representable');
+    }
     return entries;
   };
 
@@ -225,18 +236,68 @@ export const createArtifactSanitizer = (
   };
 };
 
-export const assertBlockedEgressProbe = ({ blocked, canary, control, marker, service }) => {
+export const assertNoDefaultInternetRoute = ({
+  canary,
+  control,
+  ipv4Routes,
+  ipv6Routes,
+  service,
+}) => {
   if (canary.code !== 0) {
     throw new Error(`${service} routed egress canary failed with code ${canary.code}`);
   }
   if (control.code !== 0) {
     throw new Error(`${service} egress control probe failed with code ${control.code}`);
   }
-  if (blocked.code !== 86 || blocked.stdout.trim() !== marker || blocked.stderr.trim() !== '') {
-    throw new Error(
-      `${service} egress probe did not produce the exact blocked-network contract `
-      + `(code=${blocked.code}, stdout=${JSON.stringify(blocked.stdout.trim())}, `
-      + `stderr=${JSON.stringify(blocked.stderr.trim())})`,
-    );
+  if (ipv4Routes.code !== 0 || ipv4Routes.stderr.trim() !== '') {
+    throw new Error(`${service} IPv4 route table could not be read exactly`);
+  }
+  const ipv4Lines = ipv4Routes.stdout.trim().split('\n').filter(Boolean);
+  if (ipv4Lines.length < 2 || !/^Iface\s+Destination\s+Gateway\s+Flags\b/.test(ipv4Lines[0])) {
+    throw new Error(`${service} IPv4 route table has an invalid format`);
+  }
+  const ipv4Entries = ipv4Lines.slice(1).map((line) => line.trim().split(/\s+/));
+  if (ipv4Entries.some((entry) => (
+    entry.length !== 11
+    || !/^[0-9A-Fa-f]{8}$/.test(entry[1])
+    || !/^[0-9A-Fa-f]{8}$/.test(entry[2])
+    || !/^[0-9A-Fa-f]{4}$/.test(entry[3])
+    || !entry.slice(4, 7).every((value) => /^\d+$/.test(value))
+    || !/^[0-9A-Fa-f]{8}$/.test(entry[7])
+    || !entry.slice(8).every((value) => /^\d+$/.test(value))
+  ))) {
+    throw new Error(`${service} IPv4 route table contains an invalid entry`);
+  }
+  if (ipv4Entries.some(([iface, destination, , flags, , , , mask]) => (
+    iface !== 'lo'
+    && destination === '00000000'
+    && mask === '00000000'
+    && (Number.parseInt(flags, 16) & 1) === 1
+  ))) {
+    throw new Error(`${service} has an active default IPv4 route`);
+  }
+
+  if (ipv6Routes.code !== 0 || ipv6Routes.stderr.trim() !== '') {
+    throw new Error(`${service} IPv6 route table could not be read exactly`);
+  }
+  const ipv6Entries = ipv6Routes.stdout.trim().split('\n').filter(Boolean)
+    .map((line) => line.trim().split(/\s+/));
+  if (ipv6Entries.some((entry) => (
+    entry.length !== 10
+    || !/^[0-9A-Fa-f]{32}$/.test(entry[0])
+    || !/^[0-9A-Fa-f]{2}$/.test(entry[1])
+    || !/^[0-9A-Fa-f]{32}$/.test(entry[2])
+    || !/^[0-9A-Fa-f]{2}$/.test(entry[3])
+    || !/^[0-9A-Fa-f]{32}$/.test(entry[4])
+    || !entry.slice(5, 9).every((value) => /^[0-9A-Fa-f]{8}$/.test(value))
+  ))) {
+    throw new Error(`${service} IPv6 route table contains an invalid entry`);
+  }
+  if (ipv6Entries.some((entry) => (
+    entry[0] === '00000000000000000000000000000000'
+    && entry[1] === '00'
+    && entry[9] !== 'lo'
+  ))) {
+    throw new Error(`${service} has a default IPv6 route`);
   }
 };

--- a/Promptly.Web/src/web/e2e/harness-safety.mjs
+++ b/Promptly.Web/src/web/e2e/harness-safety.mjs
@@ -1,0 +1,180 @@
+import { unzipSync, zipSync } from 'fflate';
+
+const DEFAULT_MAX_ARCHIVE_BYTES = 256 * 1024 * 1024;
+const archiveMagic = [
+  Buffer.from([0x50, 0x4b, 0x03, 0x04]),
+  Buffer.from([0x50, 0x4b, 0x05, 0x06]),
+  Buffer.from([0x50, 0x4b, 0x07, 0x08]),
+];
+const credentialPatterns = [
+  {
+    label: 'JWT',
+    pattern: /\beyJ[A-Za-z0-9_-]{2,2048}\.[A-Za-z0-9_-]{2,8192}\.[A-Za-z0-9_-]{16,1024}\b/g,
+  },
+  {
+    label: 'PASSWORD',
+    pattern: /Promptly-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-A1/g,
+  },
+];
+const htmlArchivePrefix = '<template id="playwrightReportBase64">data:application/zip;base64,';
+const htmlArchiveSuffix = '</template>';
+
+const equalLengthMask = (label, length) => {
+  const marker = `[REDACTED-${label}]`;
+  return marker.slice(0, length).padEnd(length, '*');
+};
+
+const isArchive = (name, content) => (
+  name.toLowerCase().endsWith('.zip')
+  || archiveMagic.some((magic) => content.subarray(0, magic.length).equals(magic))
+);
+
+export const createArtifactSanitizer = (
+  knownSecrets,
+  { maxArchiveBytes = DEFAULT_MAX_ARCHIVE_BYTES } = {},
+) => {
+  const secrets = [...new Set(knownSecrets.filter((secret) => (
+    typeof secret === 'string' && secret.length > 0
+  )))];
+
+  const sanitizeBuffer = (input) => {
+    const original = Buffer.from(input);
+    let text = original.toString('latin1');
+    for (const secret of secrets) {
+      text = text.replaceAll(secret, equalLengthMask('SECRET', secret.length));
+    }
+    for (const { label, pattern } of credentialPatterns) {
+      text = text.replace(pattern, (credential) => equalLengthMask(label, credential.length));
+    }
+    const content = Buffer.from(text, 'latin1');
+    return { changed: !content.equals(original), content };
+  };
+
+  const expandArchive = (input) => {
+    const archive = Buffer.from(input);
+    if (archive.length > maxArchiveBytes) {
+      throw new Error(`Compressed artifact exceeds ${maxArchiveBytes} bytes`);
+    }
+    let expandedBytes = 0;
+    const entries = unzipSync(archive, {
+      filter: (entry) => {
+        expandedBytes += entry.originalSize;
+        if (expandedBytes > maxArchiveBytes) {
+          throw new Error(`Expanded artifact exceeds ${maxArchiveBytes} bytes`);
+        }
+        return true;
+      },
+    });
+    return entries;
+  };
+
+  const inspectEntries = (entries, sanitize) => {
+    const inspected = {};
+    let changed = false;
+    for (const [name, entry] of Object.entries(entries)) {
+      const content = Buffer.from(entry);
+      if (isArchive(name, content)) {
+        throw new Error(`Nested archive is not upload-safe: ${name}`);
+      }
+      const result = sanitizeBuffer(content);
+      if (!sanitize && result.changed) {
+        throw new Error(`Compressed artifact contains credential material: ${name}`);
+      }
+      inspected[name] = result.content;
+      changed ||= result.changed;
+    }
+    return { changed, entries: inspected };
+  };
+
+  const sanitizeArchive = (input) => {
+    const archive = Buffer.from(input);
+    const inspected = inspectEntries(expandArchive(archive), true);
+    if (!inspected.changed) {
+      return { changed: false, content: archive };
+    }
+    const content = Buffer.from(zipSync(inspected.entries, { level: 6 }));
+    if (content.length > maxArchiveBytes) {
+      throw new Error(`Sanitized artifact exceeds ${maxArchiveBytes} bytes`);
+    }
+    inspectEntries(expandArchive(content), false);
+    return { changed: true, content };
+  };
+
+  const transformHtmlReport = (input, sanitize) => {
+    const html = Buffer.from(input).toString('utf8');
+    const prefixIndex = html.indexOf(htmlArchivePrefix);
+    if (prefixIndex < 0) {
+      throw new Error('Playwright HTML report does not contain its embedded archive');
+    }
+    const archiveStart = prefixIndex + htmlArchivePrefix.length;
+    const archiveEnd = html.indexOf(htmlArchiveSuffix, archiveStart);
+    if (archiveEnd < 0 || html.indexOf(htmlArchivePrefix, archiveStart) >= 0) {
+      throw new Error('Playwright HTML report has an invalid embedded-archive contract');
+    }
+    const encodedArchive = html.slice(archiveStart, archiveEnd);
+    if (!/^[A-Za-z0-9+/]+=*$/.test(encodedArchive)) {
+      throw new Error('Playwright HTML report has invalid base64 archive data');
+    }
+    const archive = Buffer.from(encodedArchive, 'base64');
+    const canonicalArchive = archive.toString('base64');
+    if (canonicalArchive !== encodedArchive) {
+      throw new Error('Playwright HTML report has noncanonical base64 archive data');
+    }
+    const outsidePrefix = Buffer.from(html.slice(0, archiveStart));
+    const outsideSuffix = Buffer.from(html.slice(archiveEnd));
+
+    if (!sanitize) {
+      assertBufferSafe(outsidePrefix);
+      assertBufferSafe(outsideSuffix);
+      assertArchiveSafe(archive);
+      return { changed: false, content: Buffer.from(html) };
+    }
+    const sanitizedArchive = sanitizeArchive(archive);
+    const sanitizedPrefix = sanitizeBuffer(outsidePrefix);
+    const sanitizedSuffix = sanitizeBuffer(outsideSuffix);
+    if (!sanitizedArchive.changed && !sanitizedPrefix.changed && !sanitizedSuffix.changed) {
+      return { changed: false, content: Buffer.from(html) };
+    }
+    const content = Buffer.from(
+      `${sanitizedPrefix.content.toString('utf8')}${sanitizedArchive.content.toString('base64')}`
+      + sanitizedSuffix.content.toString('utf8'),
+    );
+    transformHtmlReport(content, false);
+    return { changed: true, content };
+  };
+
+  const assertBufferSafe = (input) => {
+    if (sanitizeBuffer(input).changed) {
+      throw new Error('Artifact contains credential material');
+    }
+  };
+
+  const assertArchiveSafe = (input) => {
+    inspectEntries(expandArchive(input), false);
+  };
+
+  return {
+    assertArchiveSafe,
+    assertBufferSafe,
+    assertHtmlReportSafe: (input) => transformHtmlReport(input, false),
+    sanitizeArchive,
+    sanitizeBuffer,
+    sanitizeHtmlReport: (input) => transformHtmlReport(input, true),
+  };
+};
+
+export const assertBlockedEgressProbe = ({ blocked, canary, control, marker, service }) => {
+  if (canary.code !== 0) {
+    throw new Error(`${service} routed egress canary failed with code ${canary.code}`);
+  }
+  if (control.code !== 0) {
+    throw new Error(`${service} egress control probe failed with code ${control.code}`);
+  }
+  if (blocked.code !== 86 || blocked.stdout.trim() !== marker || blocked.stderr.trim() !== '') {
+    throw new Error(
+      `${service} egress probe did not produce the exact blocked-network contract `
+      + `(code=${blocked.code}, stdout=${JSON.stringify(blocked.stdout.trim())}, `
+      + `stderr=${JSON.stringify(blocked.stderr.trim())})`,
+    );
+  }
+};

--- a/Promptly.Web/src/web/e2e/harness-safety.node-test.mjs
+++ b/Promptly.Web/src/web/e2e/harness-safety.node-test.mjs
@@ -5,8 +5,9 @@ import { fileURLToPath } from 'node:url';
 import { unzipSync, zipSync } from 'fflate';
 import {
   assertNoDefaultInternetRoute,
-  createSafeRunMetadata,
   createArtifactSanitizer,
+  createPlaywrightEnvironment,
+  createSafeRunMetadata,
   resolveFixedE2EPaths,
 } from './harness-safety.mjs';
 
@@ -32,6 +33,48 @@ test('pins E2E artifacts to the repository even when the environment requests a 
     } else {
       process.env.PROMPTLY_E2E_ARTIFACT_DIR = previous;
     }
+  }
+});
+
+test('strips reporter selection and every Playwright output path from the child environment', () => {
+  const redirectedRoot = path.join(path.parse(process.cwd()).root, 'attacker-controlled-artifacts');
+  const reporterOverrides = {
+    PLAYWRIGHT_BLOB_OUTPUT_DIR: redirectedRoot,
+    PLAYWRIGHT_BLOB_OUTPUT_FILE: path.join(redirectedRoot, 'report.zip'),
+    PLAYWRIGHT_BLOB_OUTPUT_NAME: '../report.zip',
+    PLAYWRIGHT_HTML_OUTPUT_DIR: redirectedRoot,
+    PLAYWRIGHT_HTML_OUTPUT_FILE: path.join(redirectedRoot, 'html-file'),
+    PLAYWRIGHT_HTML_OUTPUT_NAME: '../html-name',
+    PLAYWRIGHT_HTML_REPORT: redirectedRoot,
+    PLAYWRIGHT_JSON_OUTPUT_DIR: redirectedRoot,
+    PLAYWRIGHT_JSON_OUTPUT_FILE: path.join(redirectedRoot, 'results.json'),
+    PLAYWRIGHT_JSON_OUTPUT_NAME: '../results.json',
+    PLAYWRIGHT_JUNIT_OUTPUT_DIR: redirectedRoot,
+    PLAYWRIGHT_JUNIT_OUTPUT_FILE: path.join(redirectedRoot, 'junit.xml'),
+    PLAYWRIGHT_JUNIT_OUTPUT_NAME: '../junit.xml',
+    PLAYWRIGHT_LAST_RUN_OUTPUT_FILE: path.join(redirectedRoot, '.last-run.json'),
+    PW_TEST_REPORTER: 'blob',
+  };
+  const environment = createPlaywrightEnvironment(
+    {
+      PATH: '/trusted/bin',
+      PLAYWRIGHT_BROWSERS_PATH: '/trusted/browser-cache',
+      PROMPTLY_E2E_WEB_ORIGIN: 'http://parent.invalid',
+      ...reporterOverrides,
+    },
+    {
+      CI: 'true',
+      PROMPTLY_E2E_API_ORIGIN: 'http://127.0.0.1:41001',
+      PROMPTLY_E2E_JWT_KEY: 'ephemeral-key',
+      PROMPTLY_E2E_WEB_ORIGIN: 'http://127.0.0.1:41002',
+    },
+  );
+
+  assert.equal(environment.PATH, '/trusted/bin');
+  assert.equal(environment.PLAYWRIGHT_BROWSERS_PATH, '/trusted/browser-cache');
+  assert.equal(environment.PROMPTLY_E2E_WEB_ORIGIN, 'http://127.0.0.1:41002');
+  for (const key of Object.keys(reporterOverrides)) {
+    assert.equal(Object.hasOwn(environment, key), false, `${key} reached the child process`);
   }
 });
 

--- a/Promptly.Web/src/web/e2e/harness-safety.node-test.mjs
+++ b/Promptly.Web/src/web/e2e/harness-safety.node-test.mjs
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { unzipSync, zipSync } from 'fflate';
+import {
+  assertBlockedEgressProbe,
+  createArtifactSanitizer,
+} from './harness-safety.mjs';
+
+const jwt = `${'eyJhbGciOiJIUzI1NiJ9'}.${'eyJzdWIiOiJ1c2VyLTEifQ'}.${'signature_value_1234567890'}`;
+const password = 'Promptly-12345678-1234-1234-1234-123456789abc-A1';
+
+test('sanitizes known and derived credentials inside compressed traces', () => {
+  const sanitizer = createArtifactSanitizer(['database-secret', 'jwt-signing-key']);
+  const trace = Buffer.from(zipSync({
+    'trace.network': Buffer.from(
+      `database-secret\nAuthorization: Bearer ${jwt}\npassword=${password}\n`,
+    ),
+    'resources/binary': Buffer.from([0, 255, 1, 2, 3]),
+  }));
+
+  assert.throws(() => sanitizer.assertArchiveSafe(trace), /credential material/);
+  const sanitized = sanitizer.sanitizeArchive(trace);
+
+  assert.equal(sanitized.changed, true);
+  sanitizer.assertArchiveSafe(sanitized.content);
+  const entries = unzipSync(sanitized.content);
+  const network = Buffer.from(entries['trace.network']).toString('utf8');
+  assert.doesNotMatch(network, /database-secret/);
+  assert.doesNotMatch(network, /eyJ/);
+  assert.doesNotMatch(network, /Promptly-/);
+  assert.deepEqual(Buffer.from(entries['resources/binary']), Buffer.from([0, 255, 1, 2, 3]));
+});
+
+test('rejects nested and over-limit archives instead of scanning them shallowly', () => {
+  const nested = Buffer.from(zipSync({
+    'nested.zip': zipSync({ 'secret.txt': Buffer.from(jwt) }),
+  }));
+  const nestedSanitizer = createArtifactSanitizer([]);
+  assert.throws(() => nestedSanitizer.sanitizeArchive(nested), /Nested archive/);
+
+  const boundedSanitizer = createArtifactSanitizer([], { maxArchiveBytes: 8 });
+  assert.throws(
+    () => boundedSanitizer.sanitizeArchive(Buffer.from(zipSync({ file: Buffer.alloc(16) }))),
+    /artifact exceeds 8 bytes/,
+  );
+});
+
+test('sanitizes Playwright HTML reports with compressed base64-embedded credentials', () => {
+  const sanitizer = createArtifactSanitizer([]);
+  const archive = Buffer.from(zipSync({
+    'report.json': Buffer.from(JSON.stringify({ error: `expected Bearer ${jwt}` })),
+  }));
+  const html = Buffer.from(
+    `<!doctype html><body>password=${password}</body>`
+    + `<template id="playwrightReportBase64">data:application/zip;base64,${archive.toString('base64')}`
+    + '</template>',
+  );
+
+  assert.throws(() => sanitizer.assertHtmlReportSafe(html), /credential material/);
+  const sanitized = sanitizer.sanitizeHtmlReport(html);
+  assert.equal(sanitized.changed, true);
+  sanitizer.assertHtmlReportSafe(sanitized.content);
+  assert.doesNotMatch(sanitized.content.toString('utf8'), /eyJ/);
+  assert.doesNotMatch(sanitized.content.toString('utf8'), /Promptly-/);
+});
+
+test('egress proof requires both a working control and exact timeout marker', () => {
+  const valid = {
+    blocked: { code: 86, stderr: '', stdout: 'PROMPTLY_EGRESS_BLOCKED\n' },
+    canary: { code: 0, stderr: '', stdout: '' },
+    control: { code: 0, stderr: '', stdout: '' },
+    marker: 'PROMPTLY_EGRESS_BLOCKED',
+    service: 'promptly-web',
+  };
+  assert.doesNotThrow(() => assertBlockedEgressProbe(valid));
+  assert.throws(
+    () => assertBlockedEgressProbe({ ...valid, canary: { code: 1, stderr: '', stdout: '' } }),
+    /routed egress canary failed/,
+  );
+  assert.throws(
+    () => assertBlockedEgressProbe({ ...valid, control: { code: 127, stderr: 'nc: not found', stdout: '' } }),
+    /control probe failed/,
+  );
+  assert.throws(
+    () => assertBlockedEgressProbe({ ...valid, blocked: { code: 1, stderr: '', stdout: '' } }),
+    /exact blocked-network contract/,
+  );
+  assert.throws(
+    () => assertBlockedEgressProbe({ ...valid, blocked: { code: 86, stderr: 'exec failed', stdout: valid.marker } }),
+    /exact blocked-network contract/,
+  );
+});
+
+test('sanitization results can be rewritten without making safe finalization fail', () => {
+  const sanitizer = createArtifactSanitizer([]);
+  const html = Buffer.from(
+    `<template id="playwrightReportBase64">data:application/zip;base64,${Buffer.from(zipSync({
+      'report.json': Buffer.from(jwt),
+    })).toString('base64')}</template>`,
+  );
+
+  const first = sanitizer.sanitizeHtmlReport(html);
+  assert.equal(first.changed, true);
+  const second = sanitizer.sanitizeHtmlReport(first.content);
+  assert.equal(second.changed, false);
+  sanitizer.assertHtmlReportSafe(second.content);
+});

--- a/Promptly.Web/src/web/e2e/harness-safety.node-test.mjs
+++ b/Promptly.Web/src/web/e2e/harness-safety.node-test.mjs
@@ -1,13 +1,55 @@
 import assert from 'node:assert/strict';
+import path from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 import { unzipSync, zipSync } from 'fflate';
 import {
   assertBlockedEgressProbe,
+  createSafeRunMetadata,
   createArtifactSanitizer,
+  resolveFixedE2EPaths,
 } from './harness-safety.mjs';
 
 const jwt = `${'eyJhbGciOiJIUzI1NiJ9'}.${'eyJzdWIiOiJ1c2VyLTEifQ'}.${'signature_value_1234567890'}`;
 const password = 'Promptly-12345678-1234-1234-1234-123456789abc-A1';
+
+test('pins E2E artifacts to the repository even when the environment requests a redirect', () => {
+  const previous = process.env.PROMPTLY_E2E_ARTIFACT_DIR;
+  const redirectedRoot = path.join(path.parse(process.cwd()).root, 'attacker-controlled-artifacts');
+  process.env.PROMPTLY_E2E_ARTIFACT_DIR = redirectedRoot;
+  try {
+    const paths = resolveFixedE2EPaths(import.meta.url);
+    const expectedE2ERoot = path.dirname(fileURLToPath(import.meta.url));
+    assert.equal(paths.e2eRoot, expectedE2ERoot);
+    assert.equal(
+      paths.artifactsRoot,
+      path.join(paths.repositoryRoot, 'artifacts/test-results/e2e'),
+    );
+    assert.notEqual(paths.artifactsRoot, redirectedRoot);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.PROMPTLY_E2E_ARTIFACT_DIR;
+    } else {
+      process.env.PROMPTLY_E2E_ARTIFACT_DIR = previous;
+    }
+  }
+});
+
+test('persists only allowlisted error categories, never runtime error contents', () => {
+  const networkDerivedSecret = 'upstream said token=network-secret';
+  const metadata = createSafeRunMetadata({
+    completedAt: new Date('2026-08-12T12:01:00.000Z'),
+    errorCategories: ['verification', networkDerivedSecret],
+    errorCount: 2,
+    startedAt: new Date('2026-08-12T12:00:00.000Z'),
+  });
+  const serialized = JSON.stringify(metadata);
+
+  assert.deepEqual(metadata.errorCategories, ['verification', 'unclassified']);
+  assert.equal(metadata.errorCount, 2);
+  assert.equal(metadata.status, 'failed');
+  assert.doesNotMatch(serialized, /network-secret|upstream said|token=/);
+});
 
 test('sanitizes known and derived credentials inside compressed traces', () => {
   const sanitizer = createArtifactSanitizer(['database-secret', 'jwt-signing-key']);

--- a/Promptly.Web/src/web/e2e/harness-safety.node-test.mjs
+++ b/Promptly.Web/src/web/e2e/harness-safety.node-test.mjs
@@ -4,7 +4,7 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { unzipSync, zipSync } from 'fflate';
 import {
-  assertBlockedEgressProbe,
+  assertNoDefaultInternetRoute,
   createSafeRunMetadata,
   createArtifactSanitizer,
   resolveFixedE2EPaths,
@@ -87,6 +87,49 @@ test('rejects nested and over-limit archives instead of scanning them shallowly'
   );
 });
 
+test('rejects duplicate ZIP entry names before a safe entry can shadow a credential', () => {
+  const shadowedName = Buffer.from('shadowed.txt');
+  const retainedName = Buffer.from('retained.txt');
+  const duplicate = Buffer.from(zipSync({
+    'shadowed.txt': Buffer.from(jwt),
+    'retained.txt': Buffer.from('safe content'),
+  }));
+  let replacements = 0;
+  for (let offset = duplicate.indexOf(shadowedName); offset >= 0;) {
+    duplicate.set(retainedName, offset);
+    replacements += 1;
+    offset = duplicate.indexOf(shadowedName, offset + retainedName.length);
+  }
+  assert.equal(replacements, 2);
+
+  const sanitizer = createArtifactSanitizer([]);
+  assert.throws(() => sanitizer.sanitizeArchive(duplicate), /duplicate entry/);
+  assert.throws(() => sanitizer.assertArchiveSafe(duplicate), /duplicate entry/);
+});
+
+test('rejects ZIP entry names that a plain-object result cannot represent safely', () => {
+  const ordinaryName = Buffer.from('safe-name');
+  const specialName = Buffer.from('__proto__');
+  const archive = Buffer.from(zipSync({
+    'safe-name': Buffer.from(jwt),
+  }));
+  let replacements = 0;
+  for (let offset = archive.indexOf(ordinaryName); offset >= 0;) {
+    archive.set(specialName, offset);
+    replacements += 1;
+    offset = archive.indexOf(ordinaryName, offset + specialName.length);
+  }
+  assert.equal(replacements, 2);
+
+  const sanitizer = createArtifactSanitizer([]);
+  assert.throws(() => sanitizer.sanitizeArchive(archive), /entry inventory/);
+  const html = Buffer.from(
+    '<template id="playwrightReportBase64">data:application/zip;base64,'
+    + `${archive.toString('base64')}</template>`,
+  );
+  assert.throws(() => sanitizer.sanitizeHtmlReport(html), /entry inventory/);
+});
+
 test('sanitizes Playwright HTML reports with compressed base64-embedded credentials', () => {
   const sanitizer = createArtifactSanitizer([]);
   const archive = Buffer.from(zipSync({
@@ -106,30 +149,73 @@ test('sanitizes Playwright HTML reports with compressed base64-embedded credenti
   assert.doesNotMatch(sanitized.content.toString('utf8'), /Promptly-/);
 });
 
-test('egress proof requires both a working control and exact timeout marker', () => {
+test('egress proof requires working controls and no workload default routes', () => {
   const valid = {
-    blocked: { code: 86, stderr: '', stdout: 'PROMPTLY_EGRESS_BLOCKED\n' },
     canary: { code: 0, stderr: '', stdout: '' },
     control: { code: 0, stderr: '', stdout: '' },
-    marker: 'PROMPTLY_EGRESS_BLOCKED',
+    ipv4Routes: {
+      code: 0,
+      stderr: '',
+      stdout: 'Iface Destination Gateway Flags RefCnt Use Metric Mask MTU Window IRTT\n'
+        + 'eth0 000013AC 00000000 0001 0 0 0 0000FFFF 0 0 0\n',
+    },
+    ipv6Routes: {
+      code: 0,
+      stderr: '',
+      stdout: '00000000000000000000000000000000 00 '
+        + '00000000000000000000000000000000 00 '
+        + '00000000000000000000000000000000 ffffffff 00000001 00000000 00200200 lo\n',
+    },
     service: 'promptly-web',
   };
-  assert.doesNotThrow(() => assertBlockedEgressProbe(valid));
+  assert.doesNotThrow(() => assertNoDefaultInternetRoute(valid));
   assert.throws(
-    () => assertBlockedEgressProbe({ ...valid, canary: { code: 1, stderr: '', stdout: '' } }),
+    () => assertNoDefaultInternetRoute({ ...valid, canary: { code: 1, stderr: '', stdout: '' } }),
     /routed egress canary failed/,
   );
   assert.throws(
-    () => assertBlockedEgressProbe({ ...valid, control: { code: 127, stderr: 'nc: not found', stdout: '' } }),
+    () => assertNoDefaultInternetRoute({
+      ...valid,
+      control: { code: 127, stderr: 'nc: not found', stdout: '' },
+    }),
     /control probe failed/,
   );
   assert.throws(
-    () => assertBlockedEgressProbe({ ...valid, blocked: { code: 1, stderr: '', stdout: '' } }),
-    /exact blocked-network contract/,
+    () => assertNoDefaultInternetRoute({
+      ...valid,
+      ipv4Routes: {
+        code: 0,
+        stderr: '',
+        stdout: valid.ipv4Routes.stdout
+          + 'eth0 00000000 010013AC 0003 0 0 0 00000000 0 0 0\n',
+      },
+    }),
+    /active default IPv4 route/,
   );
   assert.throws(
-    () => assertBlockedEgressProbe({ ...valid, blocked: { code: 86, stderr: 'exec failed', stdout: valid.marker } }),
-    /exact blocked-network contract/,
+    () => assertNoDefaultInternetRoute({
+      ...valid,
+      ipv6Routes: {
+        code: 0,
+        stderr: '',
+        stdout: valid.ipv6Routes.stdout
+          + '00000000000000000000000000000000 00 '
+          + '00000000000000000000000000000000 00 '
+          + 'fe800000000000000000000000000001 00000000 00000000 00000000 00000003 eth0\n',
+      },
+    }),
+    /default IPv6 route/,
+  );
+  assert.throws(
+    () => assertNoDefaultInternetRoute({
+      ...valid,
+      ipv4Routes: {
+        code: 0,
+        stderr: '',
+        stdout: valid.ipv4Routes.stdout.replace('0001', 'not-hex'),
+      },
+    }),
+    /invalid entry/,
   );
 });
 

--- a/Promptly.Web/src/web/e2e/required-tests.json
+++ b/Promptly.Web/src/web/e2e/required-tests.json
@@ -1,0 +1,20 @@
+{
+  "schema": 1,
+  "tests": [
+    {
+      "file": "e2e/auth.e2e.ts",
+      "project": "chromium",
+      "title": "anonymous protected routes redirect to login"
+    },
+    {
+      "file": "e2e/auth.e2e.ts",
+      "project": "chromium",
+      "title": "registration logout and login traverse the real stack"
+    },
+    {
+      "file": "e2e/auth.e2e.ts",
+      "project": "chromium",
+      "title": "an expired signed session receives 401 and clears stored authentication"
+    }
+  ]
+}

--- a/Promptly.Web/src/web/e2e/run-composed.mjs
+++ b/Promptly.Web/src/web/e2e/run-composed.mjs
@@ -13,7 +13,7 @@ import {
 } from 'node:fs/promises';
 import path from 'node:path';
 import {
-  assertBlockedEgressProbe,
+  assertNoDefaultInternetRoute,
   createSafeRunMetadata,
   createArtifactSanitizer,
   resolveFixedE2EPaths,
@@ -71,6 +71,7 @@ const artifactSanitizer = createArtifactSanitizer(secrets);
 const workerImage = `${projectName}-worker:local`;
 const projectImages = [
   `${projectName}-promptly-egress-proxy:latest`,
+  `${projectName}-promptly-ingress-gateway:latest`,
   `${projectName}-promptly-server:latest`,
   `${projectName}-promptly-web:latest`,
   workerImage,
@@ -328,6 +329,7 @@ const writeTopologyAttestation = async () => {
     'postgres',
     'promptly-egress-proxy',
     'promptly-eval',
+    'promptly-ingress-gateway',
     'promptly-server',
     'promptly-web',
     'provider-stub',
@@ -337,31 +339,34 @@ const writeTopologyAttestation = async () => {
     throw new Error(`Unexpected Compose service inventory: ${actualServiceNames.join(',')}`);
   }
   const publicServices = new Map([
-    ['promptly-server', { port: apiPort, target: 5000 }],
-    ['promptly-web', { port: webPort, target: 8080 }],
+    ['promptly-ingress-gateway', [
+      { port: apiPort, target: 5000 },
+      { port: webPort, target: 8080 },
+    ]],
   ]);
   for (const [name, service] of Object.entries(services)) {
     if (service.container_name != null) {
       throw new Error(`${name} must not use a fixed container_name`);
     }
     const ports = service.ports ?? [];
-    const expected = publicServices.get(name);
-    if (!expected && ports.length > 0) {
+    const expectedPorts = publicServices.get(name);
+    if (!expectedPorts && ports.length > 0) {
       throw new Error(`${name} unexpectedly publishes a host port`);
     }
-    if (expected) {
-      if (ports.length !== 1) {
-        throw new Error(`${name} must publish exactly one port`);
+    if (expectedPorts) {
+      if (ports.length !== expectedPorts.length) {
+        throw new Error(`${name} has an unexpected published-port count`);
       }
-      const [published] = ports;
-      if (
-        published.host_ip !== '127.0.0.1'
-        || Number(published.published) !== expected.port
-        || published.mode !== 'ingress'
-        || published.protocol !== 'tcp'
-        || Number(published.target) !== expected.target
-      ) {
-        throw new Error(`${name} has an unexpected port binding`);
+      for (const expected of expectedPorts) {
+        const published = ports.find((candidate) => Number(candidate.target) === expected.target);
+        if (
+          published?.host_ip !== '127.0.0.1'
+          || Number(published.published) !== expected.port
+          || published.mode !== 'ingress'
+          || published.protocol !== 'tcp'
+        ) {
+          throw new Error(`${name} has an unexpected ${expected.target}/tcp binding`);
+        }
       }
     }
   }
@@ -369,8 +374,9 @@ const writeTopologyAttestation = async () => {
     postgres: ['promptly-control'],
     'promptly-egress-proxy': ['promptly-control', 'promptly-egress'],
     'promptly-eval': ['promptly-control'],
-    'promptly-server': ['promptly-control', 'promptly-ingress'],
-    'promptly-web': ['promptly-control', 'promptly-ingress'],
+    'promptly-ingress-gateway': ['promptly-control', 'promptly-ingress'],
+    'promptly-server': ['promptly-control'],
+    'promptly-web': ['promptly-control'],
     'provider-stub': ['promptly-control'],
   };
   for (const [serviceName, expectedNetworksForService] of Object.entries(expectedServiceNetworks)) {
@@ -435,7 +441,12 @@ const writeTopologyAttestation = async () => {
       throw new Error(`${serviceName} has unexpected mounts`);
     }
   }
-  for (const serviceName of ['promptly-egress-proxy', 'promptly-eval', 'promptly-web']) {
+  for (const serviceName of [
+    'promptly-egress-proxy',
+    'promptly-eval',
+    'promptly-ingress-gateway',
+    'promptly-web',
+  ]) {
     if ((services[serviceName]?.volumes ?? []).length !== 0) {
       throw new Error(`${serviceName} must not have persistent or host mounts`);
     }
@@ -445,6 +456,12 @@ const writeTopologyAttestation = async () => {
     .map(([name]) => name);
   if (JSON.stringify(egressMembers) !== JSON.stringify(['promptly-egress-proxy'])) {
     throw new Error(`Unexpected egress-network membership: ${egressMembers.join(',')}`);
+  }
+  const ingressMembers = Object.entries(services)
+    .filter(([, service]) => Object.hasOwn(service.networks ?? {}, 'promptly-ingress'))
+    .map(([name]) => name);
+  if (JSON.stringify(ingressMembers) !== JSON.stringify(['promptly-ingress-gateway'])) {
+    throw new Error(`Unexpected ingress-network membership: ${ingressMembers.join(',')}`);
   }
   if (services['promptly-server']?.environment?.ASPNETCORE_ENVIRONMENT !== 'Production') {
     throw new Error('E2E server must run in Production');
@@ -466,6 +483,7 @@ const writeTopologyAttestation = async () => {
       ephemeralJwtSigningKey: true,
       internalControlNetwork: true,
       ingressIpv6Disabled: true,
+      onlyGatewayHasIngressNetwork: true,
       nonMasqueradedIngressNetwork: true,
       onlyProxyHasEgressNetwork: true,
       productionServerEnvironment: true,
@@ -473,15 +491,21 @@ const writeTopologyAttestation = async () => {
       stateMountsAreProjectScoped: true,
     },
     publishedPorts: {
-      api: { host: '127.0.0.1', port: apiPort },
-      web: { host: '127.0.0.1', port: webPort },
+      api: { gateway: 'promptly-ingress-gateway', host: '127.0.0.1', port: apiPort },
+      web: { gateway: 'promptly-ingress-gateway', host: '127.0.0.1', port: webPort },
     },
-    privateServices: ['postgres', 'provider-stub', 'promptly-egress-proxy', 'promptly-eval'],
+    privateServices: [
+      'postgres',
+      'promptly-egress-proxy',
+      'promptly-eval',
+      'promptly-server',
+      'promptly-web',
+      'provider-stub',
+    ],
   }, null, 2)}\n`);
 };
 
 const writeIngressEgressAttestation = async () => {
-  const blockedMarker = 'PROMPTLY_EGRESS_BLOCKED';
   const routedCanary = await run(
     'docker',
     [
@@ -505,28 +529,24 @@ const writeIngressEgressAttestation = async () => {
   );
   const probes = [
     {
+      service: 'promptly-eval',
+      controlCommand: [
+        'python',
+        '-c',
+        "import socket; socket.create_connection(('provider-stub', 8080), timeout=2).close()",
+      ],
+    },
+    {
       service: 'promptly-server',
       controlCommand: [
         'bash',
         '-c',
         'exec 3<>/dev/tcp/promptly-web/8080',
       ],
-      blockedCommand: [
-        'bash',
-        '-c',
-        `set -e; status=0; timeout 3 bash -c 'exec 3<>/dev/tcp/1.1.1.1/443' `
-          + `>/dev/null 2>&1 || status=$?; [ "$status" -eq 124 ]; printf '%s\\n' ${blockedMarker}; exit 86`,
-      ],
     },
     {
       service: 'promptly-web',
       controlCommand: ['nc', '-w', '2', 'promptly-server', '5000'],
-      blockedCommand: [
-        'sh',
-        '-c',
-        `set -e; status=0; timeout 3 nc 1.1.1.1 443 </dev/null >/dev/null 2>&1 `
-          + `|| status=$?; [ "$status" -eq 143 ]; printf '%s\\n' ${blockedMarker}; exit 86`,
-      ],
     },
   ];
   const results = [];
@@ -541,9 +561,9 @@ const writeIngressEgressAttestation = async () => {
         timeoutMs: 10_000,
       },
     );
-    const blocked = await run(
+    const ipv4Routes = await run(
       'docker',
-      [...composeArguments, 'exec', '--no-TTY', probe.service, ...probe.blockedCommand],
+      [...composeArguments, 'exec', '--no-TTY', probe.service, 'cat', '/proc/net/route'],
       {
         allowFailure: true,
         captureOnly: true,
@@ -551,23 +571,36 @@ const writeIngressEgressAttestation = async () => {
         timeoutMs: 10_000,
       },
     );
-    assertBlockedEgressProbe({
-      blocked,
+    const ipv6Routes = await run(
+      'docker',
+      [...composeArguments, 'exec', '--no-TTY', probe.service, 'cat', '/proc/net/ipv6_route'],
+      {
+        allowFailure: true,
+        captureOnly: true,
+        env: composeEnvironment,
+        timeoutMs: 10_000,
+      },
+    );
+    assertNoDefaultInternetRoute({
       canary: routedCanary,
       control,
-      marker: blockedMarker,
+      ipv4Routes,
+      ipv6Routes,
       service: probe.service,
     });
     results.push({
       service: probe.service,
       controlNetworkConnectionSucceeded: true,
-      directInternetConnectionRejected: true,
-      rejectionContract: 'bounded-timeout',
+      defaultIpv4RouteAbsent: true,
+      defaultIpv6RouteAbsent: true,
+      directInternetRouteAbsent: true,
     });
   }
   await writeFile(path.join(artifactsRoot, 'ingress-egress-attestation.json'), `${JSON.stringify({
     schema: 1,
-    network: 'promptly-ingress',
+    workloadNetwork: 'promptly-control',
+    hostIngressNetwork: 'promptly-ingress',
+    ingressGateway: 'promptly-ingress-gateway',
     ipMasqueradeDisabled: true,
     ipv6Disabled: true,
     routedCanary: {
@@ -886,8 +919,8 @@ try {
   }
   stackStarted = true;
   const [resolvedApiPort, resolvedWebPort] = await Promise.all([
-    resolvePublishedPort('promptly-server', 5000),
-    resolvePublishedPort('promptly-web', 8080),
+    resolvePublishedPort('promptly-ingress-gateway', 5000),
+    resolvePublishedPort('promptly-ingress-gateway', 8080),
   ]);
   if (resolvedApiPort !== apiPort || resolvedWebPort !== webPort) {
     throw new Error('Resolved Compose ports do not match the selected loopback bindings');

--- a/Promptly.Web/src/web/e2e/run-composed.mjs
+++ b/Promptly.Web/src/web/e2e/run-composed.mjs
@@ -14,8 +14,9 @@ import {
 import path from 'node:path';
 import {
   assertNoDefaultInternetRoute,
-  createSafeRunMetadata,
   createArtifactSanitizer,
+  createPlaywrightEnvironment,
+  createSafeRunMetadata,
   resolveFixedE2EPaths,
 } from './harness-safety.mjs';
 
@@ -937,13 +938,12 @@ try {
   await writeTopologyAttestation();
   await writeIngressEgressAttestation();
 
-  const playwrightEnvironment = {
-    ...process.env,
+  const playwrightEnvironment = createPlaywrightEnvironment(process.env, {
     CI: process.env.CI ?? 'true',
     PROMPTLY_E2E_API_ORIGIN: apiOrigin,
     PROMPTLY_E2E_JWT_KEY: jwtKey,
     PROMPTLY_E2E_WEB_ORIGIN: webOrigin,
-  };
+  });
 
   browserAttempted = true;
   playwrightCode = -1;

--- a/Promptly.Web/src/web/e2e/run-composed.mjs
+++ b/Promptly.Web/src/web/e2e/run-composed.mjs
@@ -1,0 +1,1141 @@
+import { spawn } from 'node:child_process';
+import { randomBytes, randomInt } from 'node:crypto';
+import { appendFileSync } from 'node:fs';
+import {
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  assertBlockedEgressProbe,
+  createArtifactSanitizer,
+} from './harness-safety.mjs';
+
+const e2eRoot = path.dirname(fileURLToPath(import.meta.url));
+const webRoot = path.dirname(e2eRoot);
+const repositoryRoot = path.resolve(webRoot, '../../..');
+const composeFile = path.join(repositoryRoot, 'docker/docker-compose.e2e.yml');
+const allowedArtifactsRoot = path.join(repositoryRoot, 'artifacts');
+const artifactsRoot = path.join(allowedArtifactsRoot, 'test-results/e2e');
+
+const prepareArtifactsDirectory = async () => {
+  let current = repositoryRoot;
+  const components = ['artifacts', 'test-results'];
+  for (const component of components) {
+    current = path.join(current, component);
+    try {
+      const information = await lstat(current);
+      if (information.isSymbolicLink() || !information.isDirectory()) {
+        throw new Error(`Artifact path component must be a real directory: ${current}`);
+      }
+    } catch (error) {
+      if (error?.code !== 'ENOENT') {
+        throw error;
+      }
+      await mkdir(current, { mode: 0o700 });
+    }
+  }
+
+  try {
+    const information = await lstat(artifactsRoot);
+    if (information.isSymbolicLink() || !information.isDirectory()) {
+      throw new Error(`Artifact output must be a real directory: ${artifactsRoot}`);
+    }
+    await rm(artifactsRoot, { recursive: true });
+  } catch (error) {
+    if (error?.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+  await mkdir(artifactsRoot, { mode: 0o700 });
+};
+
+await prepareArtifactsDirectory();
+
+const startedAt = new Date();
+const runLogPath = path.join(artifactsRoot, 'runner.log');
+const projectName = `promptly-e2e-${process.pid}-${randomBytes(6).toString('hex')}`;
+const databasePassword = randomBytes(32).toString('base64url');
+const jwtKey = randomBytes(64).toString('base64');
+const secrets = [databasePassword, jwtKey];
+const artifactSanitizer = createArtifactSanitizer(secrets);
+const workerImage = `${projectName}-worker:local`;
+const projectImages = [
+  `${projectName}-promptly-egress-proxy:latest`,
+  `${projectName}-promptly-server:latest`,
+  `${projectName}-promptly-web:latest`,
+  workerImage,
+];
+const processAbortController = new AbortController();
+let receivedSignal = null;
+let logWriteError = null;
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.once(signal, () => {
+    receivedSignal = signal;
+    processAbortController.abort(new Error(`Received ${signal}`));
+  });
+}
+
+const redact = (value) => {
+  let redacted = value;
+  for (const secret of secrets) {
+    redacted = redacted.replaceAll(secret, '[REDACTED]');
+  }
+  return redacted;
+};
+
+const appendLog = (value) => {
+  try {
+    appendFileSync(runLogPath, redact(value));
+  } catch (error) {
+    logWriteError ??= error;
+  }
+};
+
+const createRedactedStream = (destination) => {
+  let pending = '';
+
+  const flushSafePrefix = (final) => {
+    pending = redact(pending);
+    let heldLength = 0;
+    if (!final) {
+      for (const secret of secrets) {
+        const maximum = Math.min(secret.length - 1, pending.length);
+        for (let length = maximum; length > heldLength; length -= 1) {
+          if (pending.endsWith(secret.slice(0, length))) {
+            heldLength = length;
+            break;
+          }
+        }
+      }
+    }
+    const safeLength = pending.length - heldLength;
+    const safe = pending.slice(0, safeLength);
+    pending = pending.slice(safeLength);
+    if (safe.length > 0) {
+      destination.write(safe);
+      appendLog(safe);
+    }
+  };
+
+  return {
+    push(value) {
+      pending += value;
+      flushSafePrefix(false);
+    },
+    flush() {
+      flushSafePrefix(true);
+    },
+  };
+};
+
+const run = async (command, args, options = {}) => {
+  const {
+    allowFailure = false,
+    captureOnly = false,
+    cwd = repositoryRoot,
+    env = process.env,
+    ignoreAbort = false,
+    timeoutMs = 120_000,
+  } = options;
+  const commandLabel = `${command} ${args.join(' ')}`;
+  if (!captureOnly) {
+    appendLog(`\n$ ${commandLabel}\n`);
+  }
+
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    let terminationReason = null;
+    let forceKillTimer = null;
+    const stdoutStream = createRedactedStream(process.stdout);
+    const stderrStream = createRedactedStream(process.stderr);
+
+    const terminate = (reason) => {
+      if (terminationReason) {
+        return;
+      }
+      terminationReason = reason;
+      child.kill('SIGTERM');
+      forceKillTimer = setTimeout(() => child.kill('SIGKILL'), 5_000);
+      forceKillTimer.unref();
+    };
+
+    const timeout = setTimeout(
+      () => terminate(`${commandLabel} exceeded ${timeoutMs}ms`),
+      timeoutMs,
+    );
+    timeout.unref();
+    const onAbort = () => terminate(`Aborted ${commandLabel} after ${receivedSignal ?? 'cancellation'}`);
+    if (!ignoreAbort) {
+      if (processAbortController.signal.aborted) {
+        onAbort();
+      } else {
+        processAbortController.signal.addEventListener('abort', onAbort, { once: true });
+      }
+    }
+
+    const finishStreams = () => {
+      if (!captureOnly) {
+        stdoutStream.flush();
+        stderrStream.flush();
+      }
+    };
+
+    const cleanListeners = () => {
+      clearTimeout(timeout);
+      if (forceKillTimer) {
+        clearTimeout(forceKillTimer);
+      }
+      processAbortController.signal.removeEventListener('abort', onAbort);
+    };
+
+    child.stdout.on('data', (chunk) => {
+      const text = chunk.toString();
+      stdout += text;
+      if (!captureOnly) {
+        stdoutStream.push(text);
+      }
+    });
+    child.stderr.on('data', (chunk) => {
+      const text = chunk.toString();
+      stderr += text;
+      if (!captureOnly) {
+        stderrStream.push(text);
+      }
+    });
+    child.on('error', (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanListeners();
+      finishStreams();
+      reject(error);
+    });
+    child.on('close', (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanListeners();
+      finishStreams();
+      if (terminationReason) {
+        reject(new Error(terminationReason));
+        return;
+      }
+      const result = { code: code ?? -1, stderr, stdout };
+      if (result.code !== 0 && !allowFailure) {
+        reject(new Error(`${commandLabel} exited with code ${result.code}`));
+      } else {
+        resolve(result);
+      }
+    });
+  });
+};
+
+const composeEnvironment = {
+  ...process.env,
+  COMPOSE_PROJECT_NAME: projectName,
+  PROMPTLY_E2E_DATABASE_PASSWORD: databasePassword,
+  PROMPTLY_E2E_JWT_KEY: jwtKey,
+  PROMPTLY_E2E_WORKER_IMAGE: workerImage,
+};
+const composeArguments = ['compose', '--file', composeFile, '--project-name', projectName];
+const errors = [];
+let stackStarted = false;
+let apiOrigin = null;
+let apiPort = null;
+let webOrigin = null;
+let webPort = null;
+
+const configureCandidatePorts = () => {
+  apiPort = randomInt(49_152, 65_536);
+  do {
+    webPort = randomInt(49_152, 65_536);
+  } while (webPort === apiPort);
+  composeEnvironment.PROMPTLY_E2E_API_PORT = String(apiPort);
+  composeEnvironment.PROMPTLY_E2E_WEB_PORT = String(webPort);
+};
+
+const recordError = (label, error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  errors.push(`${label}: ${redact(message)}`);
+};
+
+const waitForHttp = async (url, attempts = 60) => {
+  let lastError = 'no response';
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(3_000) });
+      if (response.ok) {
+        return;
+      }
+      lastError = `HTTP ${response.status}`;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  throw new Error(`${url} did not become ready: ${lastError}`);
+};
+
+const resolvePublishedPort = async (service, target) => {
+  const binding = await run(
+    'docker',
+    [...composeArguments, 'port', service, String(target)],
+    { captureOnly: true, env: composeEnvironment },
+  );
+  const bindings = binding.stdout.split('\n').map((line) => line.trim()).filter(Boolean);
+  if (bindings.length !== 1) {
+    throw new Error(`${service} must have exactly one published ${target}/tcp binding`);
+  }
+  const match = /^127\.0\.0\.1:(\d+)$/.exec(bindings[0]);
+  const port = Number(match?.[1]);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`${service} runtime port is not loopback-only`);
+  }
+  return port;
+};
+
+const writeTopologyAttestation = async () => {
+  const configured = await run(
+    'docker',
+    [...composeArguments, 'config', '--format', 'json'],
+    { captureOnly: true, env: composeEnvironment },
+  );
+  const topology = JSON.parse(configured.stdout);
+  const services = topology.services ?? {};
+  const expectedServiceNames = [
+    'postgres',
+    'promptly-egress-proxy',
+    'promptly-eval',
+    'promptly-server',
+    'promptly-web',
+    'provider-stub',
+  ];
+  const actualServiceNames = Object.keys(services).sort();
+  if (JSON.stringify(actualServiceNames) !== JSON.stringify(expectedServiceNames)) {
+    throw new Error(`Unexpected Compose service inventory: ${actualServiceNames.join(',')}`);
+  }
+  const publicServices = new Map([
+    ['promptly-server', { port: apiPort, target: 5000 }],
+    ['promptly-web', { port: webPort, target: 8080 }],
+  ]);
+  for (const [name, service] of Object.entries(services)) {
+    if (service.container_name != null) {
+      throw new Error(`${name} must not use a fixed container_name`);
+    }
+    const ports = service.ports ?? [];
+    const expected = publicServices.get(name);
+    if (!expected && ports.length > 0) {
+      throw new Error(`${name} unexpectedly publishes a host port`);
+    }
+    if (expected) {
+      if (ports.length !== 1) {
+        throw new Error(`${name} must publish exactly one port`);
+      }
+      const [published] = ports;
+      if (
+        published.host_ip !== '127.0.0.1'
+        || Number(published.published) !== expected.port
+        || published.mode !== 'ingress'
+        || published.protocol !== 'tcp'
+        || Number(published.target) !== expected.target
+      ) {
+        throw new Error(`${name} has an unexpected port binding`);
+      }
+    }
+  }
+  const expectedServiceNetworks = {
+    postgres: ['promptly-control'],
+    'promptly-egress-proxy': ['promptly-control', 'promptly-egress'],
+    'promptly-eval': ['promptly-control'],
+    'promptly-server': ['promptly-control', 'promptly-ingress'],
+    'promptly-web': ['promptly-control', 'promptly-ingress'],
+    'provider-stub': ['promptly-control'],
+  };
+  for (const [serviceName, expectedNetworksForService] of Object.entries(expectedServiceNetworks)) {
+    const actualNetworksForService = Object.keys(services[serviceName].networks ?? {}).sort();
+    if (JSON.stringify(actualNetworksForService) !== JSON.stringify(expectedNetworksForService)) {
+      throw new Error(`${serviceName} has unexpected network membership`);
+    }
+  }
+  if (topology.networks?.['promptly-control']?.internal !== true) {
+    throw new Error('promptly-control must be an internal network');
+  }
+  const expectedNetworks = ['promptly-control', 'promptly-egress', 'promptly-ingress'];
+  if (JSON.stringify(Object.keys(topology.networks ?? {}).sort()) !== JSON.stringify(expectedNetworks)) {
+    throw new Error('Compose network inventory drifted');
+  }
+  for (const networkName of expectedNetworks) {
+    const network = topology.networks[networkName];
+    if (network.external === true || network.name !== `${projectName}_${networkName}`) {
+      throw new Error(`${networkName} must be project-scoped and non-external`);
+    }
+  }
+  const ingressNetwork = topology.networks['promptly-ingress'];
+  if (
+    ingressNetwork.driver !== 'bridge'
+    || ingressNetwork.internal === true
+    || ingressNetwork.enable_ipv6 !== false
+    || ingressNetwork.driver_opts?.['com.docker.network.bridge.enable_ip_masquerade'] !== 'false'
+  ) {
+    throw new Error(
+      'promptly-ingress must be an IPv4-only non-masqueraded bridge used only for host ingress',
+    );
+  }
+  const expectedVolumes = ['dataprotection-keys', 'postgres-data'];
+  if (JSON.stringify(Object.keys(topology.volumes ?? {}).sort()) !== JSON.stringify(expectedVolumes)) {
+    throw new Error('Compose volume inventory drifted');
+  }
+  for (const volumeName of expectedVolumes) {
+    const volume = topology.volumes[volumeName];
+    if (volume.external === true || volume.name !== `${projectName}_${volumeName}`) {
+      throw new Error(`${volumeName} must be project-scoped and non-external`);
+    }
+  }
+  const stateMounts = {
+    postgres: ['volume', 'postgres-data', '/var/lib/postgresql', false],
+    'promptly-server': ['volume', 'dataprotection-keys', '/app/dataprotection-keys', false],
+    'provider-stub': [
+      'bind',
+      path.join(repositoryRoot, 'Promptly.Worker/scripts/provider_stub.py'),
+      '/provider_stub.py',
+      true,
+    ],
+  };
+  for (const [serviceName, expectedMount] of Object.entries(stateMounts)) {
+    const mounts = services[serviceName]?.volumes ?? [];
+    if (
+      mounts.length !== 1
+      || mounts[0].type !== expectedMount[0]
+      || mounts[0].source !== expectedMount[1]
+      || mounts[0].target !== expectedMount[2]
+      || Boolean(mounts[0].read_only) !== expectedMount[3]
+    ) {
+      throw new Error(`${serviceName} has unexpected mounts`);
+    }
+  }
+  for (const serviceName of ['promptly-egress-proxy', 'promptly-eval', 'promptly-web']) {
+    if ((services[serviceName]?.volumes ?? []).length !== 0) {
+      throw new Error(`${serviceName} must not have persistent or host mounts`);
+    }
+  }
+  const egressMembers = Object.entries(services)
+    .filter(([, service]) => Object.hasOwn(service.networks ?? {}, 'promptly-egress'))
+    .map(([name]) => name);
+  if (JSON.stringify(egressMembers) !== JSON.stringify(['promptly-egress-proxy'])) {
+    throw new Error(`Unexpected egress-network membership: ${egressMembers.join(',')}`);
+  }
+  if (services['promptly-server']?.environment?.ASPNETCORE_ENVIRONMENT !== 'Production') {
+    throw new Error('E2E server must run in Production');
+  }
+  if (services['promptly-server']?.environment?.JWT__ExpiryMinutes !== '1') {
+    throw new Error('E2E JWT lifetime must remain one minute');
+  }
+  if (Buffer.from(jwtKey, 'base64').length !== 64 || databasePassword.length < 40) {
+    throw new Error('Generated E2E secrets do not meet the entropy-size contract');
+  }
+
+  await writeFile(path.join(artifactsRoot, 'topology-attestation.json'), `${JSON.stringify({
+    schema: 1,
+    checks: {
+      exactServiceInventory: true,
+      noFixedContainerNames: true,
+      disposableNamedVolumes: true,
+      ephemeralDatabaseSecret: true,
+      ephemeralJwtSigningKey: true,
+      internalControlNetwork: true,
+      ingressIpv6Disabled: true,
+      nonMasqueradedIngressNetwork: true,
+      onlyProxyHasEgressNetwork: true,
+      productionServerEnvironment: true,
+      shortJwtLifetime: true,
+      stateMountsAreProjectScoped: true,
+    },
+    publishedPorts: {
+      api: { host: '127.0.0.1', port: apiPort },
+      web: { host: '127.0.0.1', port: webPort },
+    },
+    privateServices: ['postgres', 'provider-stub', 'promptly-egress-proxy', 'promptly-eval'],
+  }, null, 2)}\n`);
+};
+
+const writeIngressEgressAttestation = async () => {
+  const blockedMarker = 'PROMPTLY_EGRESS_BLOCKED';
+  const routedCanary = await run(
+    'docker',
+    [
+      ...composeArguments,
+      'exec',
+      '--no-TTY',
+      'promptly-web',
+      'sh',
+      '-c',
+      `response="$(printf 'CONNECT 1.1.1.1:443 HTTP/1.1\\r\\nHost: 1.1.1.1:443\\r\\n\\r\\n' `
+        + `| nc -w 8 promptly-egress-proxy 4750 | head -n 1)"; `
+        + `case "$response" in 'HTTP/1.'*' 200 '*) exit 0 ;; `
+        + `*) printf '%s\\n' "$response" >&2; exit 1 ;; esac`,
+    ],
+    {
+      allowFailure: true,
+      captureOnly: true,
+      env: composeEnvironment,
+      timeoutMs: 15_000,
+    },
+  );
+  const probes = [
+    {
+      service: 'promptly-server',
+      controlCommand: [
+        'bash',
+        '-c',
+        'exec 3<>/dev/tcp/promptly-web/8080',
+      ],
+      blockedCommand: [
+        'bash',
+        '-c',
+        `set -e; status=0; timeout 3 bash -c 'exec 3<>/dev/tcp/1.1.1.1/443' `
+          + `>/dev/null 2>&1 || status=$?; [ "$status" -eq 124 ]; printf '%s\\n' ${blockedMarker}; exit 86`,
+      ],
+    },
+    {
+      service: 'promptly-web',
+      controlCommand: ['nc', '-w', '2', 'promptly-server', '5000'],
+      blockedCommand: [
+        'sh',
+        '-c',
+        `set -e; status=0; timeout 3 nc 1.1.1.1 443 </dev/null >/dev/null 2>&1 `
+          + `|| status=$?; [ "$status" -eq 143 ]; printf '%s\\n' ${blockedMarker}; exit 86`,
+      ],
+    },
+  ];
+  const results = [];
+  for (const probe of probes) {
+    const control = await run(
+      'docker',
+      [...composeArguments, 'exec', '--no-TTY', probe.service, ...probe.controlCommand],
+      {
+        allowFailure: true,
+        captureOnly: true,
+        env: composeEnvironment,
+        timeoutMs: 10_000,
+      },
+    );
+    const blocked = await run(
+      'docker',
+      [...composeArguments, 'exec', '--no-TTY', probe.service, ...probe.blockedCommand],
+      {
+        allowFailure: true,
+        captureOnly: true,
+        env: composeEnvironment,
+        timeoutMs: 10_000,
+      },
+    );
+    assertBlockedEgressProbe({
+      blocked,
+      canary: routedCanary,
+      control,
+      marker: blockedMarker,
+      service: probe.service,
+    });
+    results.push({
+      service: probe.service,
+      controlNetworkConnectionSucceeded: true,
+      directInternetConnectionRejected: true,
+      rejectionContract: 'bounded-timeout',
+    });
+  }
+  await writeFile(path.join(artifactsRoot, 'ingress-egress-attestation.json'), `${JSON.stringify({
+    schema: 1,
+    network: 'promptly-ingress',
+    ipMasqueradeDisabled: true,
+    ipv6Disabled: true,
+    routedCanary: {
+      target: '1.1.1.1:443',
+      viaEgressProxySucceeded: true,
+    },
+    results,
+  }, null, 2)}\n`);
+};
+
+const captureProviderEvidence = async (required) => {
+  const destination = path.join(artifactsRoot, 'provider-requests.jsonl');
+  await rm(destination, { force: true });
+  const captured = await run(
+    'docker',
+    [
+      ...composeArguments,
+      'exec',
+      '--no-TTY',
+      'provider-stub',
+      'cat',
+      '/tmp/provider-requests.jsonl',
+    ],
+    {
+      allowFailure: true,
+      captureOnly: true,
+      env: composeEnvironment,
+      timeoutMs: 10_000,
+    },
+  );
+  if (required && captured.code !== 0) {
+    throw new Error('Provider evidence could not be captured');
+  }
+  if (!required && captured.code !== 0) {
+    await writeFile(destination, '{"status":"unavailable-before-provider-start"}\n');
+    return;
+  }
+  await writeFile(destination, redact(captured.stdout));
+};
+
+const verifyProviderEvidence = async () => {
+  const evidencePath = path.join(artifactsRoot, 'provider-requests.jsonl');
+  const lines = (await readFile(evidencePath, 'utf8'))
+    .split('\n')
+    .filter((line) => line.trim().length > 0);
+  if (lines.length === 0) {
+    throw new Error('Provider evidence is empty');
+  }
+  const records = lines.map((line) => JSON.parse(line));
+  const sequences = new Set();
+  for (const record of records) {
+    const keys = Object.keys(record).sort();
+    const expectedKeys = ['authorized', 'kind', 'method', 'path', 'sequence'];
+    if (JSON.stringify(keys) !== JSON.stringify(expectedKeys)) {
+      throw new Error(`Provider evidence has an unexpected schema: ${keys.join(',')}`);
+    }
+    if (
+      record.authorized !== true
+      || record.kind !== 'models'
+      || record.method !== 'GET'
+      || record.path !== '/v1/models'
+      || !Number.isInteger(record.sequence)
+      || record.sequence < 1
+      || sequences.has(record.sequence)
+    ) {
+      throw new Error('Provider evidence contains an unexpected request');
+    }
+    sequences.add(record.sequence);
+  }
+};
+
+const collectDiagnostics = async () => {
+  const diagnostics = [
+    ['compose-ps.json', [...composeArguments, 'ps', '--all', '--format', 'json']],
+    ['compose-images.json', [...composeArguments, 'images', '--format', 'json']],
+    ['compose.log', [...composeArguments, 'logs', '--no-color', '--timestamps']],
+  ];
+  const failures = [];
+  for (const [fileName, args] of diagnostics) {
+    const result = await run('docker', args, {
+      allowFailure: true,
+      captureOnly: true,
+      env: composeEnvironment,
+      ignoreAbort: true,
+      timeoutMs: 30_000,
+    });
+    if (result.code !== 0) {
+      failures.push(`${fileName} command exited with code ${result.code}`);
+    }
+    const rawContent = result.stdout || result.stderr;
+    if (stackStarted && rawContent.trim().length === 0) {
+      failures.push(`${fileName} was empty after the Compose stack started`);
+    }
+    const content = redact(
+      rawContent || (fileName.endsWith('.json') ? '[]\n' : 'No Compose output was available.\n'),
+    );
+    await writeFile(path.join(artifactsRoot, fileName), content);
+  }
+  if (failures.length > 0) {
+    throw new Error(failures.join('; '));
+  }
+};
+
+const findArtifactFiles = async (directory) => {
+  const files = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await findArtifactFiles(entryPath));
+    } else if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+};
+
+const sanitizeArtifacts = async () => {
+  const sanitized = [];
+  const textPattern = /\.(?:css|html|js|json|jsonl|log|md|txt|xml)$/;
+  for (const artifactPath of await findArtifactFiles(artifactsRoot)) {
+    const content = await readFile(artifactPath);
+    const relative = path.relative(artifactsRoot, artifactPath);
+    if (relative === path.join('html', 'index.html')) {
+      const result = artifactSanitizer.sanitizeHtmlReport(content);
+      if (result.changed) {
+        const temporaryPath = `${artifactPath}.sanitized-${process.pid}`;
+        await writeFile(temporaryPath, result.content, { mode: 0o600 });
+        await rename(temporaryPath, artifactPath);
+        sanitized.push(`scrubbed-html-archive:${relative}`);
+      }
+      continue;
+    }
+    if (artifactPath.toLowerCase().endsWith('.zip')) {
+      const result = artifactSanitizer.sanitizeArchive(content);
+      if (result.changed) {
+        const temporaryPath = `${artifactPath}.sanitized-${process.pid}`;
+        await writeFile(temporaryPath, result.content, { mode: 0o600 });
+        await rename(temporaryPath, artifactPath);
+        sanitized.push(`scrubbed-archive:${relative}`);
+      }
+      continue;
+    }
+    const result = artifactSanitizer.sanitizeBuffer(content);
+    if (!result.changed) {
+      continue;
+    }
+    if (textPattern.test(artifactPath)) {
+      const temporaryPath = `${artifactPath}.sanitized-${process.pid}`;
+      await writeFile(temporaryPath, result.content, { mode: 0o600 });
+      await rename(temporaryPath, artifactPath);
+      sanitized.push(`scrubbed:${relative}`);
+    } else {
+      await rm(artifactPath);
+      sanitized.push(`removed:${relative}`);
+    }
+  }
+  return sanitized;
+};
+
+const assertArtifactsContainNoSecrets = async () => {
+  for (const artifactPath of await findArtifactFiles(artifactsRoot)) {
+    const content = await readFile(artifactPath);
+    const relative = path.relative(artifactsRoot, artifactPath);
+    try {
+      if (relative === path.join('html', 'index.html')) {
+        artifactSanitizer.assertHtmlReportSafe(content);
+      } else if (artifactPath.toLowerCase().endsWith('.zip')) {
+        artifactSanitizer.assertArchiveSafe(content);
+      } else {
+        artifactSanitizer.assertBufferSafe(content);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Artifact sanitization failed for ${relative}: ${message}`);
+    }
+  }
+};
+
+const requireNonemptyArtifact = async (relativePath) => {
+  const information = await stat(path.join(artifactsRoot, relativePath));
+  if (!information.isFile() || information.size === 0) {
+    throw new Error(`Required artifact is empty: ${relativePath}`);
+  }
+};
+
+const verifyEvidenceArtifacts = async (browserAttempted, browserFailed) => {
+  const required = ['cleanup-attestation.json', 'runner.log'];
+  if (stackStarted) {
+    required.push('compose-images.json', 'compose-ps.json', 'compose.log');
+  }
+  if (browserAttempted) {
+    required.push(
+      'html/index.html',
+      'ingress-egress-attestation.json',
+      'junit.xml',
+      'provider-requests.jsonl',
+      'results.json',
+      'topology-attestation.json',
+      'verification.json',
+    );
+  }
+  for (const relativePath of required) {
+    await requireNonemptyArtifact(relativePath);
+  }
+
+  if (browserFailed) {
+    const report = JSON.parse(await readFile(path.join(artifactsRoot, 'results.json'), 'utf8'));
+    const serialized = JSON.stringify(report.suites ?? []);
+    const hasExecutedFailure = /"status":"(?:failed|timedOut|interrupted)"/.test(serialized);
+    if (hasExecutedFailure) {
+      const files = await findArtifactFiles(path.join(artifactsRoot, 'playwright-output'));
+      for (const extension of ['.png', '.webm', '.zip']) {
+        const matching = files.filter((file) => file.endsWith(extension));
+        if (matching.length === 0) {
+          throw new Error(`Failed browser execution did not retain a ${extension} artifact`);
+        }
+        for (const artifactPath of matching) {
+          const information = await stat(artifactPath);
+          if (information.size === 0) {
+            throw new Error(`Failure artifact is empty: ${artifactPath}`);
+          }
+        }
+      }
+    }
+  }
+
+};
+
+const writeArtifactManifest = async () => {
+  const manifest = [];
+  for (const artifactPath of await findArtifactFiles(artifactsRoot)) {
+    if (artifactPath.endsWith(`${path.sep}upload-safe.json`)) {
+      continue;
+    }
+    const information = await stat(artifactPath);
+    manifest.push({
+      path: path.relative(artifactsRoot, artifactPath).split(path.sep).join('/'),
+      size: information.size,
+    });
+  }
+  manifest.sort((left, right) => left.path.localeCompare(right.path));
+  await writeFile(path.join(artifactsRoot, 'artifact-manifest.json'), `${JSON.stringify({
+    schema: 1,
+    artifacts: manifest,
+  }, null, 2)}\n`);
+};
+
+const writeRunMetadata = async () => {
+  await writeFile(path.join(artifactsRoot, 'run-metadata.json'), `${JSON.stringify({
+    schema: 1,
+    startedAt: startedAt.toISOString(),
+    completedAt: new Date().toISOString(),
+    status: errors.length === 0 ? 'passed' : 'failed',
+    webOrigin,
+    apiOrigin,
+    errors,
+  }, null, 2)}\n`);
+};
+
+let browserAttempted = false;
+let playwrightCode = null;
+
+try {
+  await run('docker', ['version', '--format', '{{.Server.Version}}'], { timeoutMs: 30_000 });
+  await run('docker', ['compose', 'version'], { timeoutMs: 30_000 });
+  configureCandidatePorts();
+  await run('docker', [...composeArguments, 'config', '--quiet'], {
+    env: composeEnvironment,
+    timeoutMs: 30_000,
+  });
+  await run('docker', [...composeArguments, 'build', '--force-rm'], {
+    env: composeEnvironment,
+    timeoutMs: 900_000,
+  });
+  let composeStarted = false;
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    const up = await run(
+      'docker',
+      [...composeArguments, 'up', '--detach', '--wait', '--wait-timeout', '180'],
+      {
+        allowFailure: true,
+        env: composeEnvironment,
+        timeoutMs: 240_000,
+      },
+    );
+    if (up.code === 0) {
+      composeStarted = true;
+      break;
+    }
+    const output = `${up.stdout}\n${up.stderr}`;
+    const portCollision = /address already in use|bind:.*failed|port is already allocated/i.test(output);
+    if (!portCollision || attempt === 5) {
+      throw new Error(`docker compose up exited with code ${up.code}`);
+    }
+    const reset = await run(
+      'docker',
+      [...composeArguments, 'down', '--volumes', '--remove-orphans', '--timeout', '10'],
+      {
+        allowFailure: true,
+        env: composeEnvironment,
+        timeoutMs: 60_000,
+      },
+    );
+    if (reset.code !== 0) {
+      throw new Error('Could not reset the Compose project after a host-port collision');
+    }
+    configureCandidatePorts();
+    await run('docker', [...composeArguments, 'config', '--quiet'], {
+      env: composeEnvironment,
+      timeoutMs: 30_000,
+    });
+  }
+  if (!composeStarted) {
+    throw new Error('Compose did not start after bounded host-port retries');
+  }
+  stackStarted = true;
+  const [resolvedApiPort, resolvedWebPort] = await Promise.all([
+    resolvePublishedPort('promptly-server', 5000),
+    resolvePublishedPort('promptly-web', 8080),
+  ]);
+  if (resolvedApiPort !== apiPort || resolvedWebPort !== webPort) {
+    throw new Error('Resolved Compose ports do not match the selected loopback bindings');
+  }
+  if (resolvedApiPort === resolvedWebPort) {
+    throw new Error('API and web services unexpectedly share a published port');
+  }
+  apiOrigin = `http://127.0.0.1:${apiPort}`;
+  webOrigin = `http://127.0.0.1:${webPort}`;
+  await Promise.all([
+    waitForHttp(`${apiOrigin}/health`),
+    waitForHttp(`${webOrigin}/healthz`),
+  ]);
+  await writeTopologyAttestation();
+  await writeIngressEgressAttestation();
+
+  const playwrightEnvironment = {
+    ...process.env,
+    CI: process.env.CI ?? 'true',
+    PROMPTLY_E2E_API_ORIGIN: apiOrigin,
+    PROMPTLY_E2E_ARTIFACT_DIR: artifactsRoot,
+    PROMPTLY_E2E_JWT_KEY: jwtKey,
+    PROMPTLY_E2E_WEB_ORIGIN: webOrigin,
+  };
+
+  browserAttempted = true;
+  playwrightCode = -1;
+  const playwright = await run(
+    path.join(webRoot, 'node_modules/.bin/playwright'),
+    ['test', '--config', 'playwright.config.ts'],
+    {
+      allowFailure: true,
+      cwd: webRoot,
+      env: playwrightEnvironment,
+      timeoutMs: 240_000,
+    },
+  );
+  playwrightCode = playwright.code;
+  const verification = await run(
+    process.execPath,
+    [path.join(e2eRoot, 'verify-results.mjs')],
+    {
+      allowFailure: true,
+      cwd: webRoot,
+      env: playwrightEnvironment,
+      timeoutMs: 30_000,
+    },
+  );
+  const browserErrors = [];
+  try {
+    await captureProviderEvidence(true);
+    await verifyProviderEvidence();
+  } catch (error) {
+    browserErrors.push(error instanceof Error ? error.message : String(error));
+  }
+  if (playwright.code !== 0) {
+    browserErrors.push(`Playwright exited with code ${playwright.code}`);
+  }
+  if (verification.code !== 0) {
+    browserErrors.push(`Required-test verification exited with code ${verification.code}`);
+  }
+  if (browserErrors.length > 0) {
+    throw new Error(browserErrors.join('; '));
+  }
+} catch (error) {
+  recordError('verification', error);
+} finally {
+  try {
+    await collectDiagnostics();
+  } catch (error) {
+    recordError('diagnostics', error);
+  }
+  if (stackStarted) {
+    try {
+      const providerPath = path.join(artifactsRoot, 'provider-requests.jsonl');
+      try {
+        await stat(providerPath);
+      } catch {
+        await captureProviderEvidence(false);
+      }
+    } catch (error) {
+      recordError('provider diagnostics', error);
+    }
+  }
+
+  let cleanupCommandPassed = false;
+  let cleanupVerificationPassed = true;
+  try {
+    const cleanup = await run(
+      'docker',
+      [...composeArguments, 'down', '--volumes', '--remove-orphans', '--rmi', 'local', '--timeout', '20'],
+      {
+        allowFailure: true,
+        env: composeEnvironment,
+        ignoreAbort: true,
+        timeoutMs: 60_000,
+      },
+    );
+    cleanupCommandPassed = cleanup.code === 0;
+    if (!cleanupCommandPassed) {
+      cleanupVerificationPassed = false;
+      recordError('cleanup', new Error(`docker compose down exited with code ${cleanup.code}`));
+    }
+  } catch (error) {
+    cleanupVerificationPassed = false;
+    recordError('cleanup', error);
+  }
+
+  for (const image of projectImages) {
+    try {
+      const inspection = await run('docker', ['image', 'inspect', image], {
+        allowFailure: true,
+        captureOnly: true,
+        ignoreAbort: true,
+        timeoutMs: 30_000,
+      });
+      if (inspection.code === 0) {
+        const removal = await run('docker', ['image', 'rm', image], {
+          allowFailure: true,
+          captureOnly: true,
+          ignoreAbort: true,
+          timeoutMs: 30_000,
+        });
+        if (removal.code !== 0) {
+          cleanupVerificationPassed = false;
+          recordError('cleanup', new Error(`Per-run image could not be removed: ${image}`));
+        }
+      } else if (!/No such (?:image|object)/i.test(inspection.stderr)) {
+        cleanupVerificationPassed = false;
+        recordError('cleanup', new Error(`Could not inspect per-run image: ${image}`));
+      }
+    } catch (error) {
+      cleanupVerificationPassed = false;
+      recordError('cleanup', error);
+    }
+  }
+
+  const leftovers = { containers: [], images: [], networks: [], volumes: [] };
+  const resourceQueries = [
+    ['containers', ['ps', '--all', '--quiet', '--filter', `label=com.docker.compose.project=${projectName}`]],
+    ['networks', ['network', 'ls', '--quiet', '--filter', `label=com.docker.compose.project=${projectName}`]],
+    ['volumes', ['volume', 'ls', '--quiet', '--filter', `label=com.docker.compose.project=${projectName}`]],
+  ];
+  for (const [resource, args] of resourceQueries) {
+    try {
+      const result = await run('docker', args, {
+        allowFailure: true,
+        captureOnly: true,
+        ignoreAbort: true,
+        timeoutMs: 30_000,
+      });
+      if (result.code !== 0) {
+        cleanupVerificationPassed = false;
+        recordError('cleanup', new Error(`Could not verify ${resource} cleanup`));
+      } else {
+        leftovers[resource] = result.stdout.trim().split('\n').filter(Boolean);
+      }
+    } catch (error) {
+      cleanupVerificationPassed = false;
+      recordError('cleanup', error);
+    }
+  }
+  for (const image of projectImages) {
+    try {
+      const result = await run('docker', ['image', 'inspect', image], {
+        allowFailure: true,
+        captureOnly: true,
+        ignoreAbort: true,
+        timeoutMs: 30_000,
+      });
+      if (result.code === 0) {
+        leftovers.images.push(image);
+      } else if (!/No such (?:image|object)/i.test(result.stderr)) {
+        cleanupVerificationPassed = false;
+        recordError('cleanup', new Error(`Could not verify image cleanup: ${image}`));
+      }
+    } catch (error) {
+      cleanupVerificationPassed = false;
+      recordError('cleanup', error);
+    }
+  }
+  if (Object.values(leftovers).some((items) => items.length > 0)) {
+    cleanupVerificationPassed = false;
+    recordError('cleanup', new Error(`Compose resources remain: ${JSON.stringify(leftovers)}`));
+  }
+  try {
+    await writeFile(path.join(artifactsRoot, 'cleanup-attestation.json'), `${JSON.stringify({
+      schema: 1,
+      cleanupCommandPassed,
+      cleanupVerificationPassed,
+      leftovers,
+    }, null, 2)}\n`);
+  } catch (error) {
+    recordError('cleanup evidence', error);
+  }
+}
+
+if (receivedSignal) {
+  recordError('termination', new Error(`Run received ${receivedSignal}`));
+}
+if (logWriteError) {
+  recordError('runner log', logWriteError);
+}
+
+try {
+  const sanitized = await sanitizeArtifacts();
+  if (sanitized.some((entry) => entry.startsWith('removed:'))) {
+    recordError(
+      'artifact sanitization',
+      new Error(`Removed unsafe binary material from: ${sanitized.join(',')}`),
+    );
+  }
+} catch (error) {
+  recordError('artifact sanitization', error);
+}
+
+try {
+  await verifyEvidenceArtifacts(browserAttempted, playwrightCode !== null && playwrightCode !== 0);
+} catch (error) {
+  recordError('artifact verification', error);
+}
+
+let uploadIsSafe = false;
+try {
+  await writeRunMetadata();
+  const sanitized = await sanitizeArtifacts();
+  if (sanitized.some((entry) => entry.startsWith('removed:'))) {
+    recordError(
+      'artifact sanitization',
+      new Error(`Removed unsafe binary material from: ${sanitized.join(',')}`),
+    );
+    await writeRunMetadata();
+  }
+  await assertArtifactsContainNoSecrets();
+  await writeArtifactManifest();
+  await assertArtifactsContainNoSecrets();
+  await writeFile(path.join(artifactsRoot, 'upload-safe.json'), '{"schema":1,"safe":true}\n');
+  uploadIsSafe = true;
+} catch (error) {
+  recordError('artifact safety', error);
+  try {
+    await sanitizeArtifacts();
+    await writeRunMetadata();
+  } catch {
+    // If safe finalization itself fails, leave no upload marker.
+  }
+}
+
+if (!uploadIsSafe) {
+  throw new Error(`Composed E2E artifacts could not be made safe for upload:\n${errors.join('\n')}`);
+}
+if (errors.length > 0) {
+  throw new Error(`Composed E2E verification failed:\n${errors.join('\n')}`);
+}
+
+console.log(`Composed E2E verification passed; artifacts: ${artifactsRoot}`);

--- a/Promptly.Web/src/web/e2e/run-composed.mjs
+++ b/Promptly.Web/src/web/e2e/run-composed.mjs
@@ -12,18 +12,20 @@ import {
   writeFile,
 } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import {
   assertBlockedEgressProbe,
+  createSafeRunMetadata,
   createArtifactSanitizer,
+  resolveFixedE2EPaths,
 } from './harness-safety.mjs';
 
-const e2eRoot = path.dirname(fileURLToPath(import.meta.url));
-const webRoot = path.dirname(e2eRoot);
-const repositoryRoot = path.resolve(webRoot, '../../..');
+const {
+  artifactsRoot,
+  e2eRoot,
+  repositoryRoot,
+  webRoot,
+} = resolveFixedE2EPaths(import.meta.url);
 const composeFile = path.join(repositoryRoot, 'docker/docker-compose.e2e.yml');
-const allowedArtifactsRoot = path.join(repositoryRoot, 'artifacts');
-const artifactsRoot = path.join(allowedArtifactsRoot, 'test-results/e2e');
 
 const prepareArtifactsDirectory = async () => {
   let current = repositoryRoot;
@@ -257,6 +259,7 @@ const composeEnvironment = {
 };
 const composeArguments = ['compose', '--file', composeFile, '--project-name', projectName];
 const errors = [];
+const errorCategories = new Set();
 let stackStarted = false;
 let apiOrigin = null;
 let apiPort = null;
@@ -275,6 +278,7 @@ const configureCandidatePorts = () => {
 const recordError = (label, error) => {
   const message = error instanceof Error ? error.message : String(error);
   errors.push(`${label}: ${redact(message)}`);
+  errorCategories.add(label);
 };
 
 const waitForHttp = async (url, attempts = 60) => {
@@ -812,15 +816,16 @@ const writeArtifactManifest = async () => {
 };
 
 const writeRunMetadata = async () => {
-  await writeFile(path.join(artifactsRoot, 'run-metadata.json'), `${JSON.stringify({
-    schema: 1,
-    startedAt: startedAt.toISOString(),
-    completedAt: new Date().toISOString(),
-    status: errors.length === 0 ? 'passed' : 'failed',
-    webOrigin,
-    apiOrigin,
-    errors,
-  }, null, 2)}\n`);
+  const metadata = createSafeRunMetadata({
+    completedAt: new Date(),
+    errorCategories: [...errorCategories],
+    errorCount: errors.length,
+    startedAt,
+  });
+  await writeFile(
+    path.join(artifactsRoot, 'run-metadata.json'),
+    `${JSON.stringify(metadata, null, 2)}\n`,
+  );
 };
 
 let browserAttempted = false;
@@ -903,7 +908,6 @@ try {
     ...process.env,
     CI: process.env.CI ?? 'true',
     PROMPTLY_E2E_API_ORIGIN: apiOrigin,
-    PROMPTLY_E2E_ARTIFACT_DIR: artifactsRoot,
     PROMPTLY_E2E_JWT_KEY: jwtKey,
     PROMPTLY_E2E_WEB_ORIGIN: webOrigin,
   };

--- a/Promptly.Web/src/web/e2e/verify-results.mjs
+++ b/Promptly.Web/src/web/e2e/verify-results.mjs
@@ -1,0 +1,189 @@
+import { readFile, readdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const e2eRoot = path.dirname(fileURLToPath(import.meta.url));
+const webRoot = path.dirname(e2eRoot);
+const artifactsRoot = path.resolve(
+  process.env.PROMPTLY_E2E_ARTIFACT_DIR
+    ?? path.join(webRoot, '../../../artifacts/test-results/e2e'),
+);
+const reportPath = path.join(artifactsRoot, 'results.json');
+const verificationPath = path.join(artifactsRoot, 'verification.json');
+const inventoryPath = path.join(e2eRoot, 'required-tests.json');
+
+const normalizeFile = (file, relativeRoot = webRoot) => {
+  if (!file) {
+    return '';
+  }
+  const absolute = path.isAbsolute(file) ? path.resolve(file) : path.resolve(relativeRoot, file);
+  if (absolute !== webRoot && !absolute.startsWith(`${webRoot}${path.sep}`)) {
+    throw new Error(`Reported test file escapes the web project: ${file}`);
+  }
+  return path.relative(webRoot, absolute).split(path.sep).join('/');
+};
+
+const identity = (test) => `${test.file}|${test.project}|${test.title}`;
+
+const collectReportedTests = (suites, reportRoot, inheritedFile = '') => {
+  const reported = [];
+  for (const suite of suites ?? []) {
+    const suiteFile = normalizeFile(suite.file, reportRoot) || inheritedFile;
+    for (const spec of suite.specs ?? []) {
+      const specFile = normalizeFile(spec.file, reportRoot) || suiteFile;
+      for (const test of spec.tests ?? []) {
+        reported.push({
+          annotations: test.annotations ?? [],
+          expectedStatus: test.expectedStatus,
+          file: specFile,
+          ok: spec.ok,
+          project: test.projectName,
+          results: test.results ?? [],
+          status: test.status,
+          tags: spec.tags ?? [],
+          title: spec.title,
+        });
+      }
+    }
+    reported.push(...collectReportedTests(suite.suites, reportRoot, suiteFile));
+  }
+  return reported;
+};
+
+const findSpecFiles = async (directory) => {
+  const files = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await findSpecFiles(entryPath));
+    } else if (entry.name.endsWith('.e2e.ts')) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+};
+
+const violations = [];
+let requiredTests = [];
+let reportedTests = [];
+
+try {
+  const inventory = JSON.parse(await readFile(inventoryPath, 'utf8'));
+  if (inventory.schema !== 1 || !Array.isArray(inventory.tests)) {
+    violations.push('Required-test inventory must use schema 1 with a tests array');
+  } else {
+    requiredTests = inventory.tests;
+  }
+
+  if (requiredTests.length === 0) {
+    violations.push('Required-test inventory is empty');
+  }
+
+  const requiredIdentities = requiredTests.map(identity);
+  if (new Set(requiredIdentities).size !== requiredIdentities.length) {
+    violations.push('Required-test inventory contains duplicate identities');
+  }
+
+  const report = JSON.parse(await readFile(reportPath, 'utf8'));
+  const reportRoot = path.resolve(report.config?.rootDir ?? '');
+  if (reportRoot !== e2eRoot) {
+    violations.push(`Playwright rootDir must resolve exactly to ${e2eRoot}`);
+  }
+  reportedTests = collectReportedTests(report.suites, reportRoot);
+  if (reportedTests.length === 0) {
+    violations.push('Playwright report contains zero tests');
+  }
+
+  const reportedIdentities = reportedTests.map(identity);
+  if (new Set(reportedIdentities).size !== reportedIdentities.length) {
+    violations.push('Playwright report contains duplicate test identities');
+  }
+
+  const expected = [...requiredIdentities].sort();
+  const actual = [...reportedIdentities].sort();
+  if (JSON.stringify(expected) !== JSON.stringify(actual)) {
+    violations.push(
+      `Required-test inventory mismatch: expected=${JSON.stringify(expected)} `
+      + `actual=${JSON.stringify(actual)}`,
+    );
+  }
+
+  if ((report.errors ?? []).length > 0) {
+    violations.push(`Playwright reported ${report.errors.length} top-level errors`);
+  }
+  if (report.config?.forbidOnly !== true) {
+    violations.push('Playwright forbidOnly must be enabled');
+  }
+  if (report.config?.fullyParallel !== false) {
+    violations.push('Playwright fullyParallel must remain disabled');
+  }
+  if (report.config?.workers !== 1) {
+    violations.push('Playwright must use exactly one worker');
+  }
+
+  const configuredProjects = report.config?.projects ?? [];
+  if (configuredProjects.length !== 1 || configuredProjects[0]?.name !== 'chromium') {
+    violations.push('Exactly one chromium project must be configured');
+  }
+  if (configuredProjects.some((project) => project.retries !== 0)) {
+    violations.push('Playwright retries must remain zero');
+  }
+  if (configuredProjects.some((project) => project.repeatEach !== 1)) {
+    violations.push('Playwright repeatEach must remain one');
+  }
+
+  for (const reported of reportedTests) {
+    const label = identity(reported);
+    if (reported.expectedStatus !== 'passed') {
+      violations.push(`${label} expectedStatus is ${reported.expectedStatus}`);
+    }
+    if (reported.status !== 'expected') {
+      violations.push(`${label} outcome classification is ${reported.status}`);
+    }
+    if (reported.ok !== true) {
+      violations.push(`${label} did not complete successfully`);
+    }
+    if (!Array.isArray(reported.annotations) || reported.annotations.length > 0) {
+      violations.push(`${label} has skip/fixme/fail annotations`);
+    }
+    if (!Array.isArray(reported.tags) || reported.tags.length > 0) {
+      violations.push(`${label} has unapproved tags: ${reported.tags.join(',')}`);
+    }
+    if (reported.results.length !== 1) {
+      violations.push(`${label} executed ${reported.results.length} attempts instead of one`);
+      continue;
+    }
+    const [result] = reported.results;
+    if (result.retry !== 0) {
+      violations.push(`${label} ran at unexpected retry index ${result.retry}`);
+    }
+    if (result.status !== 'passed') {
+      violations.push(`${label} result status is ${result.status}`);
+    }
+  }
+
+  const forbiddenSourcePattern = /\b(?:test|describe)\.(?:only|skip|fixme|fail)\b|@quarantine|\bretries\s*:/;
+  for (const specFile of await findSpecFiles(e2eRoot)) {
+    const source = await readFile(specFile, 'utf8');
+    if (forbiddenSourcePattern.test(source)) {
+      violations.push(`${normalizeFile(specFile)} contains focused, skipped, quarantined, or retry syntax`);
+    }
+  }
+} catch (error) {
+  violations.push(error instanceof Error ? error.message : String(error));
+}
+
+const verification = {
+  schema: 1,
+  requiredCount: requiredTests.length,
+  reportedCount: reportedTests.length,
+  status: violations.length === 0 ? 'passed' : 'failed',
+  violations,
+};
+await writeFile(verificationPath, `${JSON.stringify(verification, null, 2)}\n`);
+
+if (violations.length > 0) {
+  throw new Error(`E2E result verification failed:\n${violations.join('\n')}`);
+}
+
+console.log(`E2E required-test inventory verified: ${reportedTests.length}/${requiredTests.length}`);

--- a/Promptly.Web/src/web/e2e/verify-results.mjs
+++ b/Promptly.Web/src/web/e2e/verify-results.mjs
@@ -1,13 +1,12 @@
 import { readFile, readdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { resolveFixedE2EPaths } from './harness-safety.mjs';
 
-const e2eRoot = path.dirname(fileURLToPath(import.meta.url));
-const webRoot = path.dirname(e2eRoot);
-const artifactsRoot = path.resolve(
-  process.env.PROMPTLY_E2E_ARTIFACT_DIR
-    ?? path.join(webRoot, '../../../artifacts/test-results/e2e'),
-);
+const {
+  artifactsRoot,
+  e2eRoot,
+  webRoot,
+} = resolveFixedE2EPaths(import.meta.url);
 const reportPath = path.join(artifactsRoot, 'results.json');
 const verificationPath = path.join(artifactsRoot, 'verification.json');
 const inventoryPath = path.join(e2eRoot, 'required-tests.json');

--- a/Promptly.Web/src/web/eslint.config.js
+++ b/Promptly.Web/src/web/eslint.config.js
@@ -8,6 +8,14 @@ import { defineConfig, globalIgnores } from 'eslint/config'
 export default defineConfig([
   globalIgnores(['dist']),
   {
+    files: ['e2e/**/*.mjs'],
+    extends: [js.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 2023,
+      globals: globals.node,
+    },
+  },
+  {
     files: ['**/*.{ts,tsx}'],
     extends: [
       js.configs.recommended,
@@ -18,6 +26,19 @@ export default defineConfig([
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+    },
+  },
+  {
+    files: ['e2e/**/*.ts', 'playwright.config.ts'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+    rules: {
+      // Playwright fixtures receive a callback named `use`; it is not a React Hook.
+      'react-hooks/rules-of-hooks': 'off',
     },
   },
 ])

--- a/Promptly.Web/src/web/nginx.conf
+++ b/Promptly.Web/src/web/nginx.conf
@@ -1,0 +1,28 @@
+server {
+    listen 8080;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location = /healthz {
+        access_log off;
+        default_type text/plain;
+        return 200 "ready\n";
+    }
+
+    location /api/ {
+        proxy_pass http://promptly-server:5000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 30s;
+        proxy_send_timeout 30s;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/Promptly.Web/src/web/package-lock.json
+++ b/Promptly.Web/src/web/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@playwright/test": "1.62.1",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",
         "@types/node": "^24.10.1",
@@ -30,6 +31,7 @@
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
+        "fflate": "0.8.2",
         "globals": "^16.5.0",
         "jsdom": "29.1.1",
         "typescript": "~5.9.3",
@@ -1678,6 +1680,22 @@
       ],
       "engines": {
         "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@popperjs/core": {
@@ -3639,6 +3657,13 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -4668,6 +4693,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/Promptly.Web/src/web/package.json
+++ b/Promptly.Web/src/web/package.json
@@ -10,6 +10,8 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:coverage": "npm test -- --coverage",
+    "test:e2e:harness": "node --test e2e/*.node-test.mjs",
+    "test:e2e": "node e2e/run-composed.mjs",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -25,6 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@playwright/test": "1.62.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@types/node": "^24.10.1",
@@ -35,6 +38,7 @@
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
+    "fflate": "0.8.2",
     "globals": "^16.5.0",
     "jsdom": "29.1.1",
     "typescript": "~5.9.3",

--- a/Promptly.Web/src/web/playwright.config.ts
+++ b/Promptly.Web/src/web/playwright.config.ts
@@ -1,0 +1,53 @@
+import { defineConfig, devices } from '@playwright/test';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const webRoot = path.dirname(fileURLToPath(import.meta.url));
+const artifactsRoot = path.resolve(
+  process.env.PROMPTLY_E2E_ARTIFACT_DIR
+    ?? path.join(webRoot, '../../../artifacts/test-results/e2e'),
+);
+const baseURL = process.env.PROMPTLY_E2E_WEB_ORIGIN;
+
+if (!baseURL) {
+  throw new Error('PROMPTLY_E2E_WEB_ORIGIN is required; run npm run test:e2e');
+}
+
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: '**/*.e2e.ts',
+  outputDir: path.join(artifactsRoot, 'playwright-output'),
+  fullyParallel: false,
+  forbidOnly: true,
+  repeatEach: 1,
+  retries: 0,
+  workers: 1,
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  reporter: [
+    ['list'],
+    ['junit', { outputFile: path.join(artifactsRoot, 'junit.xml') }],
+    ['json', { outputFile: path.join(artifactsRoot, 'results.json') }],
+    ['html', { outputFolder: path.join(artifactsRoot, 'html'), open: 'never' }],
+  ],
+  use: {
+    baseURL,
+    actionTimeout: 10_000,
+    navigationTimeout: 15_000,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+    serviceWorkers: 'block',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        browserName: 'chromium',
+      },
+    },
+  ],
+});

--- a/Promptly.Web/src/web/playwright.config.ts
+++ b/Promptly.Web/src/web/playwright.config.ts
@@ -3,10 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const webRoot = path.dirname(fileURLToPath(import.meta.url));
-const artifactsRoot = path.resolve(
-  process.env.PROMPTLY_E2E_ARTIFACT_DIR
-    ?? path.join(webRoot, '../../../artifacts/test-results/e2e'),
-);
+const artifactsRoot = path.resolve(webRoot, '../../../artifacts/test-results/e2e');
 const baseURL = process.env.PROMPTLY_E2E_WEB_ORIGIN;
 
 if (!baseURL) {

--- a/Promptly.Web/src/web/src/api/client.test.ts
+++ b/Promptly.Web/src/web/src/api/client.test.ts
@@ -6,7 +6,7 @@ import {
   type InternalAxiosRequestConfig,
 } from 'axios';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { apiClient } from './client';
+import { apiClient, resolveApiBaseUrl } from './client';
 
 const originalAdapter = apiClient.defaults.adapter;
 
@@ -52,6 +52,18 @@ describe('apiClient', () => {
     expect(apiClient.defaults.baseURL).toBe('http://localhost:5000/api');
     expect(apiClient.defaults.headers['Content-Type']).toBe('application/json');
   });
+
+  it.each([
+    [undefined, false, 'http://localhost:5000/api'],
+    [undefined, true, '/api'],
+    ['   ', true, '/api'],
+    ['https://promptly.example/', true, 'https://promptly.example/api'],
+  ])(
+    'resolves configured and environment-specific API roots',
+    (configured, production, expected) => {
+      expect(resolveApiBaseUrl(configured, production)).toBe(expected);
+    },
+  );
 
   it('adds the stored bearer token before dispatching a request', async () => {
     localStorage.setItem('auth_token', 'token-1');

--- a/Promptly.Web/src/web/src/api/client.ts
+++ b/Promptly.Web/src/web/src/api/client.ts
@@ -1,9 +1,19 @@
 import axios from 'axios';
 
-const baseURL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000';
+export const resolveApiBaseUrl = (
+  configuredBaseUrl: string | undefined,
+  production: boolean,
+): string => {
+  const normalizedBaseUrl = configuredBaseUrl?.trim().replace(/\/+$/, '');
+  if (normalizedBaseUrl) {
+    return `${normalizedBaseUrl}/api`;
+  }
+
+  return production ? '/api' : 'http://localhost:5000/api';
+};
 
 export const apiClient = axios.create({
-  baseURL: `${baseURL}/api`,
+  baseURL: resolveApiBaseUrl(import.meta.env.VITE_API_BASE_URL, import.meta.env.PROD),
   headers: {
     'Content-Type': 'application/json',
   },

--- a/Promptly.Web/src/web/tsconfig.e2e.json
+++ b/Promptly.Web/src/web/tsconfig.e2e.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.e2e.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "types": ["node"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["playwright.config.ts", "e2e/**/*.ts"]
+}

--- a/Promptly.Web/src/web/tsconfig.json
+++ b/Promptly.Web/src/web/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.e2e.json" }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -183,7 +183,9 @@ Configuration via environment variables:
 
 Configuration via environment variables:
 
-- **VITE_API_BASE_URL**: Base URL for C# API (default: `http://localhost:5000`)
+- **VITE_API_BASE_URL**: Optional explicit base URL for the C# API. Development defaults
+  to `http://localhost:5000`; production builds default to the same-origin `/api` route
+  used by the static web container's reverse proxy.
 
 ## Usage
 
@@ -349,6 +351,19 @@ cd Promptly.Web/src/web
 npm install
 npm run dev
 ```
+
+**Production-composed browser gate**:
+```bash
+cd Promptly.Web/src/web
+npm ci
+npx playwright install chromium
+npm run test:e2e
+```
+
+This bounded Playwright foundation uses disposable Compose state and real web, API,
+PostgreSQL, worker, and deterministic-provider services. See
+[`Promptly.Web/src/web/e2e/README.md`](Promptly.Web/src/web/e2e/README.md) for its exact
+test inventory, evidence paths, failure policy, and remaining #24 scope.
 
 ### Database Migrations
 

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -1,0 +1,210 @@
+services:
+  postgres:
+    image: postgres:18.4-alpine3.23@sha256:996d0920e4ff9df1fc19dacb904492f3c1ec0ec1cc338f0ad7123be7731c5f5e
+    environment:
+      POSTGRES_DB: promptly_e2e
+      POSTGRES_USER: promptly_e2e
+      POSTGRES_PASSWORD: ${PROMPTLY_E2E_DATABASE_PASSWORD:?PROMPTLY_E2E_DATABASE_PASSWORD must be set}
+    volumes:
+      - postgres-data:/var/lib/postgresql
+    networks:
+      - promptly-control
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U promptly_e2e -d promptly_e2e"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
+    restart: "no"
+
+  provider-stub:
+    image: ${PROMPTLY_E2E_WORKER_IMAGE:?PROMPTLY_E2E_WORKER_IMAGE must be set}
+    entrypoint:
+      - python
+      - /provider_stub.py
+      - --bind-all
+      - --record-evidence
+    working_dir: /tmp
+    volumes:
+      - ../Promptly.Worker/scripts/provider_stub.py:/provider_stub.py:ro
+    networks:
+      - promptly-control
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=16m,mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - >-
+          import socket;
+          connection=socket.create_connection(('127.0.0.1',8080),timeout=2);
+          connection.close()
+      interval: 3s
+      timeout: 3s
+      retries: 20
+      start_period: 3s
+    restart: "no"
+
+  promptly-egress-proxy:
+    build:
+      context: egress-proxy
+      dockerfile: Dockerfile
+    expose:
+      - "4750"
+    networks:
+      - promptly-control
+      - promptly-egress
+    user: "65532:65532"
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=16m,mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 128
+    mem_limit: 128m
+    cpus: 1.0
+    init: true
+    stop_grace_period: 20s
+    healthcheck:
+      test: ["CMD", "/smokescreen-healthcheck"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
+    restart: "no"
+
+  promptly-eval:
+    image: ${PROMPTLY_E2E_WORKER_IMAGE:?PROMPTLY_E2E_WORKER_IMAGE must be set}
+    build:
+      context: ..
+      dockerfile: Promptly.Worker/Dockerfile
+    environment:
+      PROMPTLY_LLM_PROVIDER: openai
+      PROMPTLY_LLM_API_KEY: verification-only
+      PROMPTLY_LLM_BASE_URL: http://provider-stub:8080/v1
+      PROMPTLY_LLM_MODEL_DEFAULT: verification-model
+      PROMPTLY_LLM_TIMEOUT_SECONDS: "5"
+      HTTP_PROXY: http://promptly-egress-proxy:4750
+      HTTPS_PROXY: http://promptly-egress-proxy:4750
+      ALL_PROXY: ""
+      NO_PROXY: localhost,127.0.0.1,::1,promptly-server,promptly-eval,postgres,provider-stub
+      http_proxy: http://promptly-egress-proxy:4750
+      https_proxy: http://promptly-egress-proxy:4750
+      all_proxy: ""
+      no_proxy: localhost,127.0.0.1,::1,promptly-server,promptly-eval,postgres,provider-stub
+    expose:
+      - "8000"
+    networks:
+      - promptly-control
+    depends_on:
+      provider-stub:
+        condition: service_healthy
+      promptly-egress-proxy:
+        condition: service_healthy
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=32m,mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - >-
+          import urllib.request;
+          urllib.request.urlopen('http://127.0.0.1:8000/health/ready',timeout=3).read()
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+    restart: "no"
+
+  promptly-server:
+    build:
+      context: ..
+      dockerfile: Promptly.Server/Dockerfile
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ASPNETCORE_HTTP_PORTS: "5000"
+      ConnectionStrings__Default: Host=postgres;Database=promptly_e2e;Username=promptly_e2e;Password=${PROMPTLY_E2E_DATABASE_PASSWORD:?PROMPTLY_E2E_DATABASE_PASSWORD must be set}
+      JWT__Issuer: Promptly-E2E
+      JWT__Audience: Promptly-E2E
+      JWT__Key: ${PROMPTLY_E2E_JWT_KEY:?PROMPTLY_E2E_JWT_KEY must be set}
+      JWT__RetiredKeyFingerprints: ""
+      JWT__ExpiryMinutes: "1"
+      AuthenticationAbuse__ApiReplicaCount: "1"
+      AuthenticationAbuse__MaximumConcurrentAuthenticationRequests: "64"
+      DATA_PROTECTION_PATH: /app/dataprotection-keys
+      PROMPTLY_EVAL_BASE_URL: http://promptly-eval:8000
+      EndpointEgress__RequireProxy: "true"
+      EndpointEgress__ProxyUrl: http://promptly-egress-proxy:4750
+      HTTP_PROXY: ""
+      HTTPS_PROXY: ""
+      ALL_PROXY: ""
+      NO_PROXY: ""
+      http_proxy: ""
+      https_proxy: ""
+      all_proxy: ""
+      no_proxy: ""
+    ports:
+      - "127.0.0.1:${PROMPTLY_E2E_API_PORT:?PROMPTLY_E2E_API_PORT must be set}:5000"
+    volumes:
+      - dataprotection-keys:/app/dataprotection-keys
+    networks:
+      - promptly-control
+      - promptly-ingress
+    depends_on:
+      postgres:
+        condition: service_healthy
+      promptly-eval:
+        condition: service_healthy
+      promptly-egress-proxy:
+        condition: service_healthy
+    restart: "no"
+
+  promptly-web:
+    build:
+      context: ../Promptly.Web/src/web
+      dockerfile: Dockerfile
+    ports:
+      - "127.0.0.1:${PROMPTLY_E2E_WEB_PORT:?PROMPTLY_E2E_WEB_PORT must be set}:8080"
+    networks:
+      - promptly-control
+      - promptly-ingress
+    depends_on:
+      promptly-server:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--output-document=-", "http://127.0.0.1:8080/healthz"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
+    restart: "no"
+
+networks:
+  promptly-control:
+    driver: bridge
+    internal: true
+  promptly-ingress:
+    driver: bridge
+    enable_ipv6: false
+    driver_opts:
+      com.docker.network.bridge.enable_ip_masquerade: "false"
+  promptly-egress:
+    driver: bridge
+
+volumes:
+  postgres-data:
+  dataprotection-keys:

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -157,13 +157,10 @@ services:
       https_proxy: ""
       all_proxy: ""
       no_proxy: ""
-    ports:
-      - "127.0.0.1:${PROMPTLY_E2E_API_PORT:?PROMPTLY_E2E_API_PORT must be set}:5000"
     volumes:
       - dataprotection-keys:/app/dataprotection-keys
     networks:
       - promptly-control
-      - promptly-ingress
     depends_on:
       postgres:
         condition: service_healthy
@@ -177,11 +174,8 @@ services:
     build:
       context: ../Promptly.Web/src/web
       dockerfile: Dockerfile
-    ports:
-      - "127.0.0.1:${PROMPTLY_E2E_WEB_PORT:?PROMPTLY_E2E_WEB_PORT must be set}:8080"
     networks:
       - promptly-control
-      - promptly-ingress
     depends_on:
       promptly-server:
         condition: service_started
@@ -191,6 +185,37 @@ services:
       timeout: 3s
       retries: 20
       start_period: 5s
+    restart: "no"
+
+  promptly-ingress-gateway:
+    build:
+      context: e2e-ingress-gateway
+      dockerfile: Dockerfile
+    ports:
+      - "127.0.0.1:${PROMPTLY_E2E_API_PORT:?PROMPTLY_E2E_API_PORT must be set}:5000"
+      - "127.0.0.1:${PROMPTLY_E2E_WEB_PORT:?PROMPTLY_E2E_WEB_PORT must be set}:8080"
+    networks:
+      - promptly-control
+      - promptly-ingress
+    depends_on:
+      promptly-server:
+        condition: service_started
+      promptly-web:
+        condition: service_healthy
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=16m,mode=1777
+      - /var/cache/nginx:rw,noexec,nosuid,nodev,size=16m,mode=0755
+      - /var/run:rw,noexec,nosuid,nodev,size=1m,mode=0755
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 64
+    mem_limit: 64m
+    cpus: 0.5
+    init: true
+    stop_grace_period: 10s
     restart: "no"
 
 networks:

--- a/docker/e2e-ingress-gateway/Dockerfile
+++ b/docker/e2e-ingress-gateway/Dockerfile
@@ -1,0 +1,12 @@
+ARG RUNTIME_IMAGE=nginxinc/nginx-unprivileged:1.29.4-alpine@sha256:a6c4f61f456b85b8fdf7ec7ab28cc3e299440e6fb4a9dea520e5fd8fd440025e
+FROM ${RUNTIME_IMAGE}
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+USER 101:101
+EXPOSE 5000 8080
+
+HEALTHCHECK --interval=5s --timeout=3s --start-period=5s --retries=12 \
+  CMD wget --quiet --output-document=- http://127.0.0.1:8080/healthz >/dev/null \
+    && wget --quiet --output-document=- http://127.0.0.1:5000/health >/dev/null \
+    || exit 1

--- a/docker/e2e-ingress-gateway/nginx.conf
+++ b/docker/e2e-ingress-gateway/nginx.conf
@@ -1,0 +1,31 @@
+server {
+    listen 8080;
+    server_name _;
+
+    location / {
+        proxy_pass http://promptly-web:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 30s;
+        proxy_send_timeout 30s;
+    }
+}
+
+server {
+    listen 5000;
+    server_name _;
+
+    location / {
+        proxy_pass http://promptly-server:5000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 30s;
+        proxy_send_timeout 30s;
+    }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,6 +18,30 @@ job; the worker workflow executes those contracts separately against the real wo
 The web workflow enforces the aggregate 90% line/branch threshold and the same threshold for
 the authentication error parser plus Login and Register pages individually.
 
+## Browser end-to-end tests
+
+The first checked-in Playwright slice proves the authentication/session boundary against a
+standalone production-composed stack: anonymous redirect, real UI registration/logout/login,
+and an expired signed JWT producing a real API 401, redirect, and storage cleanup. It does not
+claim the still-blocked project-to-result, CRUD/navigation, demo, or mapping journeys in #24.
+
+Run the exact gate from the web directory:
+
+```bash
+cd Promptly.Web/src/web
+npm ci
+npx playwright install chromium
+npm run test:e2e
+```
+
+The suite has a schema-versioned exact inventory, zero retries, no quarantine path, same-origin
+browser egress and error guards, per-run secrets and Compose state, bounded readiness, and
+unconditional cleanup. JUnit, JSON, HTML, failure media, sanitized provider evidence, Compose
+diagnostics, and topology/cleanup attestations are stored under
+`artifacts/test-results/e2e`. Retained trace archives are recursively inspected and sanitized
+before the workflow can create its upload-safe marker. See `Promptly.Web/src/web/e2e/README.md`
+for the complete policy.
+
 This expanding gate is not evidence of repository-wide 90% C# coverage; Application services and Server sources outside the named cohorts, plus Domain, SDK, and CLI, remain outside its denominator. Issues #18 and #19 remain open until every unit-testable production area is included in the required aggregate gates.
 
 ## Integration tests


### PR DESCRIPTION
## Summary

- add the first checked-in Chromium Playwright gate for anonymous redirect, real UI registration/logout/login, and expired signed-session handling
- run those journeys against a disposable production-like Compose stack with static nginx web, Production ASP.NET API, PostgreSQL, real worker, deterministic provider stub, and controlled egress proxy
- fail closed on inventory drift, skips/focus/retries, browser errors/egress, topology drift, missing evidence, credential-bearing artifacts, and cleanup leftovers
- add the read-only PR/main workflow with SHA-pinned actions and document the exact local command and remaining #24 scope

## Why

Promptly had no reproducible browser regression suite. The existing Compose path is development-oriented and could not prove real authentication/session behavior with disposable state, production routing, bounded cleanup, or upload-safe diagnostics.

The first production container build also exposed an inherited SDK mismatch: floating `sdk:10.0` had advanced to 10.0.400 while `global.json` allows only the 10.0.3xx feature band. This PR narrowly aligns the Server build stage to 10.0.302; full digest pinning and image hardening remain in #68.

## Validation

- `npm run test:e2e`: 3/3 required Chromium journeys passed; provider/topology/egress/cleanup attestations passed; zero leftover per-run resources
- `npm run test:e2e:harness`: 5/5 fail-closed harness tests passed, including compressed/base64 report credential sanitization and egress proof negative cases
- `npm run test:coverage`: 155/155 web tests; 97.60% lines and 92.60% branches
- `npm run typecheck`
- `npm run lint -- --max-warnings=0`
- `npm run build`
- `npm audit --audit-level=moderate`: 0 vulnerabilities
- `git diff --check`

Closes #67

Parent: #24
Program: #47
Depends on: #70